### PR TITLE
Docs - split docs on feature changes on each full release

### DIFF
--- a/docs/preview/features/cloudevent/receive-cloudevents-job.md
+++ b/docs/preview/features/cloudevent/receive-cloudevents-job.md
@@ -5,8 +5,6 @@ layout: default
 
 # Securely Receive CloudEvents
 
-![](https://img.shields.io/badge/Available%20starting-v0.1-green?link=https://github.com/arcus-azure/arcus.backgroundjobs/releases/tag/v0.1.0)
-
 The `Arcus.BackgroundJobs.CloudEvents` library provides a collection of background jobs to securely receive [CloudEvents](https://github.com/cloudevents/spec).
 
 This allows workloads to asynchronously process event from other components without exposing a public endpoint.

--- a/docs/preview/features/cloudevent/receive-cloudevents-job.md
+++ b/docs/preview/features/cloudevent/receive-cloudevents-job.md
@@ -1,0 +1,48 @@
+---
+title: "Securely Receive CloudEvents"
+layout: default
+---
+
+# Securely Receive CloudEvents
+
+![](https://img.shields.io/badge/Available%20starting-v0.1-green?link=https://github.com/arcus-azure/arcus.backgroundjobs/releases/tag/v0.1.0)
+
+The `Arcus.BackgroundJobs.CloudEvents` library provides a collection of background jobs to securely receive [CloudEvents](https://github.com/cloudevents/spec).
+
+This allows workloads to asynchronously process event from other components without exposing a public endpoint.
+
+## How does it work?
+
+An Azure Service Bus Topic resource is required to receive CloudEvents on. CloudEvent messages on this Topic will be processed by a background job.
+
+![Automatically Invalidate Azure Key Vault Secrets](/media/CloudEvents-Job.png)
+
+You can write your own background job(s) by deriving from `CloudEventBackgroundJob` which already takes care of topic subscription creation/deletion on start/stop of the job.
+
+## Usage
+
+You can easily implement your own job by implementing the `ProcessMessageAsync` method to prcocess new CloudEvents.
+
+```csharp
+public class MyBackgroundJob : CloudEventBackgroundJob
+{
+    public MyBackgroundJob(
+        IConfiguration configuration,
+        IServiceProvider serviceProvider,
+        ILogger<CloudEventBackgroundJob> logger) : base(configuration, serviceProvider, logger)
+    {
+
+    }
+
+    protected override async Task ProcessMessageAsync(
+        CloudEvent message,
+        AzureServiceBusMessageContext messageContext,
+        MessageCorrelationInfo correlationInfo,
+        CancellationToken cancellationToken)
+        {
+            // Process the CloudEvent message...
+    }
+}
+```
+
+[&larr; back](/)

--- a/docs/preview/features/security/auto-invalidate-secrets.md
+++ b/docs/preview/features/security/auto-invalidate-secrets.md
@@ -5,8 +5,6 @@ layout: default
 
 # Automatically Invalidate Azure Key Vault Secrets
 
-![](https://img.shields.io/badge/Available%20starting-v0.1-green?link=https://github.com/arcus-azure/arcus.backgroundjobs/releases/tag/v0.1.0)
-
 The `Arcus.BackgroundJobs.KeyVault` library provides a background job to automatically invalidate cached Azure Key Vault secrets from an `ICachedSecretProvider` instance of your choice.
 
 ## How does it work?

--- a/docs/preview/features/security/auto-invalidate-secrets.md
+++ b/docs/preview/features/security/auto-invalidate-secrets.md
@@ -1,0 +1,52 @@
+---
+title: "Automatically Invalidate Azure Key Vault Secrets"
+layout: default
+---
+
+# Automatically Invalidate Azure Key Vault Secrets
+
+![](https://img.shields.io/badge/Available%20starting-v0.1-green?link=https://github.com/arcus-azure/arcus.backgroundjobs/releases/tag/v0.1.0)
+
+The `Arcus.BackgroundJobs.KeyVault` library provides a background job to automatically invalidate cached Azure Key Vault secrets from an `ICachedSecretProvider` instance of your choice.
+
+## How does it work?
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Farcus.azure%2Farcus.backgroundjobs%2Fmaster%2Fdeploy%2Farm%2Fazure-key-vault-job.json" target="_blank">
+    <img src="https://azuredeploy.net/deploybutton.png"/>
+</a>
+
+
+This automation works by subscribing on the `SecretNewVersionCreated` event of an Azure Key Vault resource and placing those events on a Azure Service Bus Topic; which we process in our background job.
+
+![Automatically Invalidate Azure Key Vault Secrets](/media/Azure-Key-Vault-Job.png)
+
+To make this automation opperational, following Azure Resources has to be used:
+* Azure Key Vault instance
+* Azure Service Bus Topic
+* Azure Event Grid subscription for `SecretNewVersionCreated` events that are sent to the Azure Service Bus Topic
+
+## Usage
+
+Our background job has to be configured in `ConfigureServices` method:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
+    //     this will get the 'serviceBusTopicConnectionStringSecretKey' string (configured below) and has to retrieve the connection string for the topic.
+    services.AddSingleton<ISecretProvider>(serviceProvider => ...);
+
+    // An `ICachedSecretProvider` implementation which secret keys will automatically be invalidated.
+    services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(mySecretProvider));
+
+    services.AddAutoInvalidateKeyVaultSecretBackgroundJob(
+        // Prefix of the Azure Service Bus Topic subscription;
+        //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
+        subscriptionNamePrefix: "MyPrefix"
+
+        // Connection string secret key to a Azure Service Bus Topic.
+        serviceBusTopicConnectionStringSecretKey: "MySecretKeyToServiceBusTopicConnectionString");
+}
+```
+
+[&larr; back](/)

--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -1,0 +1,31 @@
+---
+title: "Home"
+layout: default
+permalink: /
+redirect_from:
+ - /index.html
+---
+
+[![NuGet Badge](https://buildstats.info/nuget/Arcus.BackgroundJobs.CloudEvents?includePreReleases=true)](https://www.nuget.org/packages/Arcus.BackgroundJobs.CloudEvents/)
+
+# Installation
+
+The Arcus BackgroundJobs can be installed via NuGet:
+
+```shell
+PM > Install-Package Arcus.BackgroundJobs.CloudEvents
+```
+
+For more granular packages we recommend reading the documentation.
+
+# Features
+
+- **General**
+    - [Securely Receive CloudEvents](features/cloudevent/receive-cloudevents-job)
+- **Security**
+    - [Automatically invalidate cached secrets from Azure Key Vault](features/security/auto-invalidate-secrets)
+
+# License
+This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.
+
+*[Full license here](https://github.com/arcus-azure/arcus.backgroundjobs/blob/master/LICENSE)*

--- a/docs/v0.1/features/cloudevent/receive-cloudevents-job.md
+++ b/docs/v0.1/features/cloudevent/receive-cloudevents-job.md
@@ -5,8 +5,6 @@ layout: default
 
 # Securely Receive CloudEvents
 
-![](https://img.shields.io/badge/Available%20starting-v0.1-green?link=https://github.com/arcus-azure/arcus.backgroundjobs/releases/tag/v0.1.0)
-
 The `Arcus.BackgroundJobs.CloudEvents` library provides a collection of background jobs to securely receive [CloudEvents](https://github.com/cloudevents/spec).
 
 This allows workloads to asynchronously process event from other components without exposing a public endpoint.

--- a/docs/v0.1/features/cloudevent/receive-cloudevents-job.md
+++ b/docs/v0.1/features/cloudevent/receive-cloudevents-job.md
@@ -1,0 +1,48 @@
+---
+title: "Securely Receive CloudEvents"
+layout: default
+---
+
+# Securely Receive CloudEvents
+
+![](https://img.shields.io/badge/Available%20starting-v0.1-green?link=https://github.com/arcus-azure/arcus.backgroundjobs/releases/tag/v0.1.0)
+
+The `Arcus.BackgroundJobs.CloudEvents` library provides a collection of background jobs to securely receive [CloudEvents](https://github.com/cloudevents/spec).
+
+This allows workloads to asynchronously process event from other components without exposing a public endpoint.
+
+## How does it work?
+
+An Azure Service Bus Topic resource is required to receive CloudEvents on. CloudEvent messages on this Topic will be processed by a background job.
+
+![Automatically Invalidate Azure Key Vault Secrets](/media/CloudEvents-Job.png)
+
+You can write your own background job(s) by deriving from `CloudEventBackgroundJob` which already takes care of topic subscription creation/deletion on start/stop of the job.
+
+## Usage
+
+You can easily implement your own job by implementing the `ProcessMessageAsync` method to prcocess new CloudEvents.
+
+```csharp
+public class MyBackgroundJob : CloudEventBackgroundJob
+{
+    public MyBackgroundJob(
+        IConfiguration configuration,
+        IServiceProvider serviceProvider,
+        ILogger<CloudEventBackgroundJob> logger) : base(configuration, serviceProvider, logger)
+    {
+
+    }
+
+    protected override async Task ProcessMessageAsync(
+        CloudEvent message,
+        AzureServiceBusMessageContext messageContext,
+        MessageCorrelationInfo correlationInfo,
+        CancellationToken cancellationToken)
+        {
+            // Process the CloudEvent message...
+    }
+}
+```
+
+[&larr; back](/)

--- a/docs/v0.1/features/security/auto-invalidate-secrets.md
+++ b/docs/v0.1/features/security/auto-invalidate-secrets.md
@@ -5,8 +5,6 @@ layout: default
 
 # Automatically Invalidate Azure Key Vault Secrets
 
-![](https://img.shields.io/badge/Available%20starting-v0.1-green?link=https://github.com/arcus-azure/arcus.backgroundjobs/releases/tag/v0.1.0)
-
 The `Arcus.BackgroundJobs.KeyVault` library provides a background job to automatically invalidate cached Azure Key Vault secrets from an `ICachedSecretProvider` instance of your choice.
 
 ## How does it work?

--- a/docs/v0.1/features/security/auto-invalidate-secrets.md
+++ b/docs/v0.1/features/security/auto-invalidate-secrets.md
@@ -1,0 +1,52 @@
+---
+title: "Automatically Invalidate Azure Key Vault Secrets"
+layout: default
+---
+
+# Automatically Invalidate Azure Key Vault Secrets
+
+![](https://img.shields.io/badge/Available%20starting-v0.1-green?link=https://github.com/arcus-azure/arcus.backgroundjobs/releases/tag/v0.1.0)
+
+The `Arcus.BackgroundJobs.KeyVault` library provides a background job to automatically invalidate cached Azure Key Vault secrets from an `ICachedSecretProvider` instance of your choice.
+
+## How does it work?
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Farcus.azure%2Farcus.backgroundjobs%2Fmaster%2Fdeploy%2Farm%2Fazure-key-vault-job.json" target="_blank">
+    <img src="https://azuredeploy.net/deploybutton.png"/>
+</a>
+
+
+This automation works by subscribing on the `SecretNewVersionCreated` event of an Azure Key Vault resource and placing those events on a Azure Service Bus Topic; which we process in our background job.
+
+![Automatically Invalidate Azure Key Vault Secrets](/media/Azure-Key-Vault-Job.png)
+
+To make this automation opperational, following Azure Resources has to be used:
+* Azure Key Vault instance
+* Azure Service Bus Topic
+* Azure Event Grid subscription for `SecretNewVersionCreated` events that are sent to the Azure Service Bus Topic
+
+## Usage
+
+Our background job has to be configured in `ConfigureServices` method:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
+    //     this will get the 'serviceBusTopicConnectionStringSecretKey' string (configured below) and has to retrieve the connection string for the topic.
+    services.AddSingleton<ISecretProvider>(serviceProvider => ...);
+
+    // An `ICachedSecretProvider` implementation which secret keys will automatically be invalidated.
+    services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(mySecretProvider));
+
+    services.AddAutoInvalidateKeyVaultSecretBackgroundJob(
+        // Prefix of the Azure Service Bus Topic subscription;
+        //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
+        subscriptionNamePrefix: "MyPrefix"
+
+        // Connection string secret key to a Azure Service Bus Topic.
+        serviceBusTopicConnectionStringSecretKey: "MySecretKeyToServiceBusTopicConnectionString");
+}
+```
+
+[&larr; back](/)

--- a/docs/v0.1/index.md
+++ b/docs/v0.1/index.md
@@ -1,9 +1,6 @@
 ---
 title: "Home"
 layout: default
-permalink: /
-redirect_from:
- - /index.html
 ---
 
 [![NuGet Badge](https://buildstats.info/nuget/Arcus.BackgroundJobs.CloudEvents?packageVersion=0.1.0)](https://www.nuget.org/packages/Arcus.BackgroundJobs.CloudEvents/0.1.0)

--- a/docs/v0.1/index.md
+++ b/docs/v0.1/index.md
@@ -1,0 +1,31 @@
+---
+title: "Home"
+layout: default
+permalink: /
+redirect_from:
+ - /index.html
+---
+
+[![NuGet Badge](https://buildstats.info/nuget/Arcus.BackgroundJobs.CloudEvents?packageVersion=0.1.0)](https://www.nuget.org/packages/Arcus.BackgroundJobs.CloudEvents/0.1.0)
+
+# Installation
+
+The Arcus BackgroundJobs can be installed via NuGet:
+
+```shell
+PM > Install-Package Arcus.BackgroundJobs.CloudEvents -Version 0.1.0
+```
+
+For more granular packages we recommend reading the documentation.
+
+# Features
+
+- **General**
+    - [Securely Receive CloudEvents](features/cloudevent/receive-cloudevents-job)
+- **Security**
+    - [Automatically invalidate cached secrets from Azure Key Vault](features/security/auto-invalidate-secrets)
+
+# License
+This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.
+
+*[Full license here](https://github.com/arcus-azure/arcus.backgroundjobs/blob/master/LICENSE)*


### PR DESCRIPTION
* All the docs are marked with a version since when it's available
* All the docs are split onto changes for each full release
* The "currenly available, but not yet released" features have been split into the `preview` folder
* The `./docs/features` folder contains now the available features of the most recent version (inclusive the preview releases)

Relates to https://github.com/arcus-azure/arcus/issues/75