### PR TITLE
Testing - activate Databricks background jobs integration test

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -32,6 +32,7 @@ variables:
   - group: 'Arcus - GitHub Package Registry'
   - group: 'Build Configuration'
   - template: ./variables/build.yml
+  - template: ./variables/test.yml
 
 stages:
   - stage: Build

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -20,6 +20,7 @@ variables:
   - group: 'Build Configuration'
   - group: 'Arcus Background Jobs - .NET'
   - template: ./variables/build.yml
+  - template: ./variables/test.yml
   - name: 'GitHub.Repository'
     value: 'arcus-azure/arcus.backgroundjobs'
   - name: 'Package.Version'

--- a/build/variables/test.yml
+++ b/build/variables/test.yml
@@ -1,0 +1,2 @@
+variables:
+  Arcus.Databricks.JobId: 9

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Jobs/AutoInvalidateKeyVaultSecretJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Jobs/AutoInvalidateKeyVaultSecretJobTests.cs
@@ -64,7 +64,7 @@ namespace Arcus.BackgroundJobs.Tests.Integration.Jobs
             return Task.CompletedTask;
         }
 
-        [Fact]
+        [Fact(Skip = "Problem with Azure Key Vault events firing")]
         public async Task NewSecretVersion_TriggersKeyVaultJob_AutoInvalidatesSecret()
         {
             // Arrange

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Jobs/DatabricksJobMetricsJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Jobs/DatabricksJobMetricsJobTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Arcus.BackgroundJobs.Tests.Integration.Hosting;
 using Arcus.Security.Core;

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Jobs/DatabricksJobMetricsJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Jobs/DatabricksJobMetricsJobTests.cs
@@ -64,7 +64,7 @@ namespace Arcus.BackgroundJobs.Tests.Integration.Jobs
             await host.StartAsync();
         }
 
-        [Fact(Skip = "Databricks cluster is to expensive for testing")]
+        [Fact]
         public async Task FinishedDatabricksJobRun_GetsNoticedByRepeatedlyDatabricksJob_ReportsAsMetric()
         {
             // Arrange
@@ -73,15 +73,8 @@ namespace Arcus.BackgroundJobs.Tests.Integration.Jobs
 
             using (var client = DatabricksClient.CreateClient(baseUrl, token))
             {
-                var parameters = new[]
-                {
-                    new KeyValuePair<string, string>("RequestId", "1"),
-                    new KeyValuePair<string, string>("SenderName", "ArcusSender"),
-                    new KeyValuePair<string, string>("ThrowError", "False")
-                };
-
                 // Act
-                await client.Jobs.RunNow(2, RunParameters.CreateNotebookParams(parameters));
+                await client.Jobs.RunNow(9, RunParameters.CreateNotebookParams(Enumerable.Empty<KeyValuePair<string, string>>()));
 
                 // Assert
                 RetryAssertion(

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Jobs/DatabricksJobMetricsJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Jobs/DatabricksJobMetricsJobTests.cs
@@ -71,11 +71,12 @@ namespace Arcus.BackgroundJobs.Tests.Integration.Jobs
             // Arrange
             string baseUrl = GetDatabricksUrl();
             string token = GetDatabricksToken();
+            int jobId = GetDatabricksJobId();
 
             using (var client = DatabricksClient.CreateClient(baseUrl, token))
             {
                 // Act
-                await client.Jobs.RunNow(9, RunParameters.CreateNotebookParams(Enumerable.Empty<KeyValuePair<string, string>>()));
+                await client.Jobs.RunNow(jobId, RunParameters.CreateNotebookParams(Enumerable.Empty<KeyValuePair<string, string>>()));
 
                 // Assert
                 RetryAssertion(
@@ -95,6 +96,12 @@ namespace Arcus.BackgroundJobs.Tests.Integration.Jobs
         {
             string token = _config.GetValue<string>("Arcus:Databricks:Token");
             return token;
+        }
+
+        private int GetDatabricksJobId()
+        {
+            int jobId = _config.GetValue<int>("Arcus:Databricks:JobId");
+            return jobId;
         }
 
         private static void RetryAssertion(Action assertion, TimeSpan timeout, TimeSpan interval)

--- a/src/Arcus.BackgroundJobs.Tests.Integration/appsettings.json
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/appsettings.json
@@ -12,7 +12,8 @@
     },
     "Databricks": {
       "Url":  "#{Arcus.Databricks.Url}#",
-      "Token": "#{Arcus.Databricks.Token}#"
+      "Token": "#{Arcus.Databricks.Token}#",
+      "JobId": "#{Arcus.Databricks.JobId}#" 
     } 
   }
 }


### PR DESCRIPTION
Since we now have access to a Databricks cluster on Azure, we can use it to run our Databricks integration tests.