### PR TITLE
Docs - add missing 'using's to the feature docs

### DIFF
--- a/docs/features/cloudevent/receive-cloudevents-job.md
+++ b/docs/features/cloudevent/receive-cloudevents-job.md
@@ -22,6 +22,12 @@ You can write your own background job(s) by deriving from `CloudEventBackgroundJ
 You can easily implement your own job by implementing the `ProcessMessageAsync` method to prcocess new CloudEvents.
 
 ```csharp
+using Arcus.BackgroundJobs.CloudEvents;
+using CloudNative.CloudEvents;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 public class MyBackgroundJob : CloudEventBackgroundJob
 {
     public MyBackgroundJob(

--- a/docs/features/databricks/gain-insights.md
+++ b/docs/features/databricks/gain-insights.md
@@ -21,6 +21,10 @@ We provide a  `DatabricksInfoProvider` which allows you to interact with Databri
 It can be easily setup and used anywhere such as .NET Core workers, Azure Functions and more. We are using this ourselves for our [job metrics](./job-metrics).
 
 ```csharp
+using Arcus.BackgroundJobs.Databricks;
+using Microsoft.Azure.Databricks.Client;
+using Microsoft.Extensions.Logging;
+
 ILogger logger = ...
 using (var client = DatabricksClient.CreateClient("https://databricks.base.url", "security.token"))
 using (var provider = new DatabricksInfoProvider(client, logger))
@@ -45,6 +49,8 @@ Measures the finished job runs by reporting the results as (multi-dimensional) m
 This method is an combination of the previously defined method (**Getting finished jobs**) and calling an `ILogger` extension provided in this package (`ILogger.LogMetricFinishedJobOutcome`) which will write the finished job runs `JobRun` instances as metrics.
 
 ```csharp
+using Arcus.BackgroundJobs.Databricks;
+
 DatabricksInfoProvider provider = ...
 var metricName = "Databricks Job Completed";
 var startOfWindow = DateTimeOffset.UtcNow.AddDays(-1);

--- a/docs/features/databricks/gain-insights.md
+++ b/docs/features/databricks/gain-insights.md
@@ -35,6 +35,8 @@ using (var provider = new DatabricksInfoProvider(client, logger))
 ### Getting finished job run information
 Gets all the finished job runs within a given time window.
 ```csharp
+using Arcus.BackgroundJobs.Databricks;
+
 DatabricksInfoProvider provider = ...
 var startOfWindow = DateTimeOffset.UtcNow.AddDays(-1);
 var endOfWindow = DateTimeOffset.UtcNow;

--- a/docs/features/databricks/job-metrics.md
+++ b/docs/features/databricks/job-metrics.md
@@ -22,31 +22,37 @@ PM > Install-Package Arcus.BackgroundJobs.Databricks
 Our background job has to be configured in `ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Arcus.Security.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
-    //     this will get the 'tokenSecretKey' string (configured below) and has to retrieve the connection token for the Databricks instance.
-    services.AddSingleton<ISecretProvider>(serviceProvider => ...);
-
-    // Simplest registration of the scheduler job:
-    services.AddDatabricksJobMetricsJob(
-        baseUrl: "https://url.to.databricks.instance/" 
-        // Token secret key to connect to the Databricks token.
-        tokenSecretKey: "Databricks.Token");
-
-    // Customized registration of the scheduler job:
-    services.AddDatabricksJobMetricsJob(
-        baseUrl: "https://url.to.databricks.instance/" 
-        // Token secret key to connect to the Databricks token.
-        tokenSecretKey: "Databricks.Token",
-        options =>
-        {
-            // Setting the name which will be used when reporting the metric for finished Databricks job runs (default: "Databricks Job Completed").
-            options.MetricName = "MyDatabricksJobMetric";
-
-            // Settings the time interval (in minutes) in which the scheduler job should run (default: 5 minutes). 
-            options.IntervalInMinutes = 6;
-        });
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
+        //     this will get the 'tokenSecretKey' string (configured below) and has to retrieve the connection token for the Databricks instance.
+        services.AddSingleton<ISecretProvider>(serviceProvider => ...);
+    
+        // Simplest registration of the scheduler job:
+        services.AddDatabricksJobMetricsJob(
+            baseUrl: "https://url.to.databricks.instance/" 
+            // Token secret key to connect to the Databricks token.
+            tokenSecretKey: "Databricks.Token");
+    
+        // Customized registration of the scheduler job:
+        services.AddDatabricksJobMetricsJob(
+            baseUrl: "https://url.to.databricks.instance/" 
+            // Token secret key to connect to the Databricks token.
+            tokenSecretKey: "Databricks.Token",
+            options =>
+            {
+                // Setting the name which will be used when reporting the metric for finished Databricks job runs (default: "Databricks Job Completed").
+                options.MetricName = "MyDatabricksJobMetric";
+    
+                // Settings the time interval (in minutes) in which the scheduler job should run (default: 5 minutes). 
+                options.IntervalInMinutes = 6;
+            });
+    }
 }
 ```
 

--- a/docs/features/security/auto-invalidate-secrets.md
+++ b/docs/features/security/auto-invalidate-secrets.md
@@ -28,22 +28,29 @@ To make this automation opperational, following Azure Resources has to be used:
 Our background job has to be configured in `ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Arcus.Security.Core;
+using Arcus.Security.Core.Caching;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
-    //     this will get the 'serviceBusTopicConnectionStringSecretKey' string (configured below) and has to retrieve the connection string for the topic.
-    services.AddSingleton<ISecretProvider>(serviceProvider => ...);
-
-    // An `ICachedSecretProvider` implementation which secret keys will automatically be invalidated.
-    services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(mySecretProvider));
-
-    services.AddAutoInvalidateKeyVaultSecretBackgroundJob(
-        // Prefix of the Azure Service Bus Topic subscription;
-        //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
-        subscriptionNamePrefix: "MyPrefix"
-
-        // Connection string secret key to a Azure Service Bus Topic.
-        serviceBusTopicConnectionStringSecretKey: "MySecretKeyToServiceBusTopicConnectionString");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
+        //     this will get the 'serviceBusTopicConnectionStringSecretKey' string (configured below) and has to retrieve the connection string for the topic.
+        services.AddSingleton<ISecretProvider>(serviceProvider => ...);
+    
+        // An `ICachedSecretProvider` implementation which secret keys will automatically be invalidated.
+        services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(mySecretProvider));
+    
+        services.AddAutoInvalidateKeyVaultSecretBackgroundJob(
+            // Prefix of the Azure Service Bus Topic subscription;
+            //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
+            subscriptionNamePrefix: "MyPrefix"
+    
+            // Connection string secret key to a Azure Service Bus Topic.
+            serviceBusTopicConnectionStringSecretKey: "MySecretKeyToServiceBusTopicConnectionString");
+    }
 }
 ```
 

--- a/docs/preview/features/cloudevent/receive-cloudevents-job.md
+++ b/docs/preview/features/cloudevent/receive-cloudevents-job.md
@@ -22,6 +22,12 @@ You can write your own background job(s) by deriving from `CloudEventBackgroundJ
 You can easily implement your own job by implementing the `ProcessMessageAsync` method to prcocess new CloudEvents.
 
 ```csharp
+using Arcus.BackgroundJobs.CloudEvents;
+using CloudNative.CloudEvents;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 public class MyBackgroundJob : CloudEventBackgroundJob
 {
     public MyBackgroundJob(

--- a/docs/preview/features/databricks/gain-insights.md
+++ b/docs/preview/features/databricks/gain-insights.md
@@ -21,6 +21,10 @@ We provide a  `DatabricksInfoProvider` which allows you to interact with Databri
 It can be easily setup and used anywhere such as .NET Core workers, Azure Functions and more. We are using this ourselves for our [job metrics](./job-metrics).
 
 ```csharp
+using Arcus.BackgroundJobs.Databricks;
+using Microsoft.Azure.Databricks.Client;
+using Microsoft.Extensions.Logging;
+
 ILogger logger = ...
 using (var client = DatabricksClient.CreateClient("https://databricks.base.url", "security.token"))
 using (var provider = new DatabricksInfoProvider(client, logger))
@@ -31,6 +35,8 @@ using (var provider = new DatabricksInfoProvider(client, logger))
 ### Getting finished job run information
 Gets all the finished job runs within a given time window.
 ```csharp
+using Arcus.BackgroundJobs.Databricks;
+
 DatabricksInfoProvider provider = ...
 var startOfWindow = DateTimeOffset.UtcNow.AddDays(-1);
 var endOfWindow = DateTimeOffset.UtcNow;
@@ -45,6 +51,8 @@ Measures the finished job runs by reporting the results as (multi-dimensional) m
 This method is an combination of the previously defined method (**Getting finished jobs**) and calling an `ILogger` extension provided in this package (`ILogger.LogMetricFinishedJobOutcome`) which will write the finished job runs `JobRun` instances as metrics.
 
 ```csharp
+using Arcus.BackgroundJobs.Databricks;
+
 DatabricksInfoProvider provider = ...
 var metricName = "Databricks Job Completed";
 var startOfWindow = DateTimeOffset.UtcNow.AddDays(-1);

--- a/docs/preview/features/databricks/job-metrics.md
+++ b/docs/preview/features/databricks/job-metrics.md
@@ -22,31 +22,37 @@ PM > Install-Package Arcus.BackgroundJobs.Databricks
 Our background job has to be configured in `ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Arcus.Security.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
-    //     this will get the 'tokenSecretKey' string (configured below) and has to retrieve the connection token for the Databricks instance.
-    services.AddSingleton<ISecretProvider>(serviceProvider => ...);
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
+        //     this will get the 'tokenSecretKey' string (configured below) and has to retrieve the connection token for the Databricks instance.
+        services.AddSingleton<ISecretProvider>(serviceProvider => ...);
 
-    // Simplest registration of the scheduler job:
-    services.AddDatabricksJobMetricsJob(
-        baseUrl: "https://url.to.databricks.instance/" 
-        // Token secret key to connect to the Databricks token.
-        tokenSecretKey: "Databricks.Token");
+        // Simplest registration of the scheduler job:
+        services.AddDatabricksJobMetricsJob(
+            baseUrl: "https://url.to.databricks.instance/" 
+            // Token secret key to connect to the Databricks token.
+            tokenSecretKey: "Databricks.Token");
 
-    // Customized registration of the scheduler job:
-    services.AddDatabricksJobMetricsJob(
-        baseUrl: "https://url.to.databricks.instance/" 
-        // Token secret key to connect to the Databricks token.
-        tokenSecretKey: "Databricks.Token",
-        options =>
-        {
-            // Setting the name which will be used when reporting the metric for finished Databricks job runs (default: "Databricks Job Completed").
-            options.MetricName = "MyDatabricksJobMetric";
+        // Customized registration of the scheduler job:
+        services.AddDatabricksJobMetricsJob(
+            baseUrl: "https://url.to.databricks.instance/" 
+            // Token secret key to connect to the Databricks token.
+            tokenSecretKey: "Databricks.Token",
+            options =>
+            {
+                // Setting the name which will be used when reporting the metric for finished Databricks job runs (default: "Databricks Job Completed").
+                options.MetricName = "MyDatabricksJobMetric";
 
-            // Settings the time interval (in minutes) in which the scheduler job should run (default: 5 minutes). 
-            options.IntervalInMinutes = 6;
-        });
+                // Settings the time interval (in minutes) in which the scheduler job should run (default: 5 minutes). 
+                options.IntervalInMinutes = 6;
+            });
+    }
 }
 ```
 

--- a/docs/preview/features/security/auto-invalidate-secrets.md
+++ b/docs/preview/features/security/auto-invalidate-secrets.md
@@ -28,22 +28,29 @@ To make this automation opperational, following Azure Resources has to be used:
 Our background job has to be configured in `ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Arcus.Security.Core;
+using Arcus.Security.Core.Caching;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
-    //     this will get the 'serviceBusTopicConnectionStringSecretKey' string (configured below) and has to retrieve the connection string for the topic.
-    services.AddSingleton<ISecretProvider>(serviceProvider => ...);
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
+        //     this will get the 'serviceBusTopicConnectionStringSecretKey' string (configured below) and has to retrieve the connection string for the topic.
+        services.AddSingleton<ISecretProvider>(serviceProvider => ...);
 
-    // An `ICachedSecretProvider` implementation which secret keys will automatically be invalidated.
-    services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(mySecretProvider));
+        // An `ICachedSecretProvider` implementation which secret keys will automatically be invalidated.
+        services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(mySecretProvider));
 
-    services.AddAutoInvalidateKeyVaultSecretBackgroundJob(
-        // Prefix of the Azure Service Bus Topic subscription;
-        //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
-        subscriptionNamePrefix: "MyPrefix"
+        services.AddAutoInvalidateKeyVaultSecretBackgroundJob(
+            // Prefix of the Azure Service Bus Topic subscription;
+            //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
+            subscriptionNamePrefix: "MyPrefix"
 
-        // Connection string secret key to a Azure Service Bus Topic.
-        serviceBusTopicConnectionStringSecretKey: "MySecretKeyToServiceBusTopicConnectionString");
+            // Connection string secret key to a Azure Service Bus Topic.
+            serviceBusTopicConnectionStringSecretKey: "MySecretKeyToServiceBusTopicConnectionString");
+    }
 }
 ```
 

--- a/docs/v0.1/features/cloudevent/receive-cloudevents-job.md
+++ b/docs/v0.1/features/cloudevent/receive-cloudevents-job.md
@@ -22,6 +22,12 @@ You can write your own background job(s) by deriving from `CloudEventBackgroundJ
 You can easily implement your own job by implementing the `ProcessMessageAsync` method to prcocess new CloudEvents.
 
 ```csharp
+using Arcus.BackgroundJobs.CloudEvents;
+using CloudNative.CloudEvents;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 public class MyBackgroundJob : CloudEventBackgroundJob
 {
     public MyBackgroundJob(

--- a/docs/v0.1/features/security/auto-invalidate-secrets.md
+++ b/docs/v0.1/features/security/auto-invalidate-secrets.md
@@ -28,22 +28,29 @@ To make this automation opperational, following Azure Resources has to be used:
 Our background job has to be configured in `ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Arcus.Security.Core;
+using Arcus.Security.Core.Caching;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
-    //     this will get the 'serviceBusTopicConnectionStringSecretKey' string (configured below) and has to retrieve the connection string for the topic.
-    services.AddSingleton<ISecretProvider>(serviceProvider => ...);
-
-    // An `ICachedSecretProvider` implementation which secret keys will automatically be invalidated.
-    services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(mySecretProvider));
-
-    services.AddAutoInvalidateKeyVaultSecretBackgroundJob(
-        // Prefix of the Azure Service Bus Topic subscription;
-        //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
-        subscriptionNamePrefix: "MyPrefix"
-
-        // Connection string secret key to a Azure Service Bus Topic.
-        serviceBusTopicConnectionStringSecretKey: "MySecretKeyToServiceBusTopicConnectionString");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
+        //     this will get the 'serviceBusTopicConnectionStringSecretKey' string (configured below) and has to retrieve the connection string for the topic.
+        services.AddSingleton<ISecretProvider>(serviceProvider => ...);
+    
+        // An `ICachedSecretProvider` implementation which secret keys will automatically be invalidated.
+        services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(mySecretProvider));
+    
+        services.AddAutoInvalidateKeyVaultSecretBackgroundJob(
+            // Prefix of the Azure Service Bus Topic subscription;
+            //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
+            subscriptionNamePrefix: "MyPrefix"
+    
+            // Connection string secret key to a Azure Service Bus Topic.
+            serviceBusTopicConnectionStringSecretKey: "MySecretKeyToServiceBusTopicConnectionString");
+    }
 }
 ```
 

--- a/docs/v0.2/features/cloudevent/receive-cloudevents-job.md
+++ b/docs/v0.2/features/cloudevent/receive-cloudevents-job.md
@@ -22,6 +22,12 @@ You can write your own background job(s) by deriving from `CloudEventBackgroundJ
 You can easily implement your own job by implementing the `ProcessMessageAsync` method to prcocess new CloudEvents.
 
 ```csharp
+using Arcus.BackgroundJobs.CloudEvents;
+using CloudNative.CloudEvents;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 public class MyBackgroundJob : CloudEventBackgroundJob
 {
     public MyBackgroundJob(

--- a/docs/v0.2/features/databricks/gain-insights.md
+++ b/docs/v0.2/features/databricks/gain-insights.md
@@ -21,6 +21,10 @@ We provide a  `DatabricksInfoProvider` which allows you to interact with Databri
 It can be easily setup and used anywhere such as .NET Core workers, Azure Functions and more. We are using this ourselves for our [job metrics](./job-metrics).
 
 ```csharp
+using Arcus.BackgroundJobs.Databricks;
+using Microsoft.Azure.Databricks.Client;
+using Microsoft.Extensions.Logging;
+
 ILogger logger = ...
 using (var client = DatabricksClient.CreateClient("https://databricks.base.url", "security.token"))
 using (var provider = new DatabricksInfoProvider(client, logger))
@@ -31,6 +35,8 @@ using (var provider = new DatabricksInfoProvider(client, logger))
 ### Getting finished job run information
 Gets all the finished job runs within a given time window.
 ```csharp
+using Arcus.BackgroundJobs.Databricks;
+
 DatabricksInfoProvider provider = ...
 var startOfWindow = DateTimeOffset.UtcNow.AddDays(-1);
 var endOfWindow = DateTimeOffset.UtcNow;
@@ -45,6 +51,8 @@ Measures the finished job runs by reporting the results as (multi-dimensional) m
 This method is an combination of the previously defined method (**Getting finished jobs**) and calling an `ILogger` extension provided in this package (`ILogger.LogMetricFinishedJobOutcome`) which will write the finished job runs `JobRun` instances as metrics.
 
 ```csharp
+using Arcus.BackgroundJobs.Databricks;
+
 DatabricksInfoProvider provider = ...
 var metricName = "Databricks Job Completed";
 var startOfWindow = DateTimeOffset.UtcNow.AddDays(-1);

--- a/docs/v0.2/features/databricks/job-metrics.md
+++ b/docs/v0.2/features/databricks/job-metrics.md
@@ -22,31 +22,37 @@ PM > Install-Package Arcus.BackgroundJobs.Databricks
 Our background job has to be configured in `ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Arcus.Security.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
-    //     this will get the 'tokenSecretKey' string (configured below) and has to retrieve the connection token for the Databricks instance.
-    services.AddSingleton<ISecretProvider>(serviceProvider => ...);
-
-    // Simplest registration of the scheduler job:
-    services.AddDatabricksJobMetricsJob(
-        baseUrl: "https://url.to.databricks.instance/" 
-        // Token secret key to connect to the Databricks token.
-        tokenSecretKey: "Databricks.Token");
-
-    // Customized registration of the scheduler job:
-    services.AddDatabricksJobMetricsJob(
-        baseUrl: "https://url.to.databricks.instance/" 
-        // Token secret key to connect to the Databricks token.
-        tokenSecretKey: "Databricks.Token",
-        options =>
-        {
-            // Setting the name which will be used when reporting the metric for finished Databricks job runs (default: "Databricks Job Completed").
-            options.MetricName = "MyDatabricksJobMetric";
-
-            // Settings the time interval (in minutes) in which the scheduler job should run (default: 5 minutes). 
-            options.IntervalInMinutes = 6;
-        });
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
+        //     this will get the 'tokenSecretKey' string (configured below) and has to retrieve the connection token for the Databricks instance.
+        services.AddSingleton<ISecretProvider>(serviceProvider => ...);
+    
+        // Simplest registration of the scheduler job:
+        services.AddDatabricksJobMetricsJob(
+            baseUrl: "https://url.to.databricks.instance/" 
+            // Token secret key to connect to the Databricks token.
+            tokenSecretKey: "Databricks.Token");
+    
+        // Customized registration of the scheduler job:
+        services.AddDatabricksJobMetricsJob(
+            baseUrl: "https://url.to.databricks.instance/" 
+            // Token secret key to connect to the Databricks token.
+            tokenSecretKey: "Databricks.Token",
+            options =>
+            {
+                // Setting the name which will be used when reporting the metric for finished Databricks job runs (default: "Databricks Job Completed").
+                options.MetricName = "MyDatabricksJobMetric";
+    
+                // Settings the time interval (in minutes) in which the scheduler job should run (default: 5 minutes). 
+                options.IntervalInMinutes = 6;
+            });
+    }
 }
 ```
 

--- a/docs/v0.2/features/security/auto-invalidate-secrets.md
+++ b/docs/v0.2/features/security/auto-invalidate-secrets.md
@@ -28,22 +28,29 @@ To make this automation opperational, following Azure Resources has to be used:
 Our background job has to be configured in `ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Arcus.Security.Core;
+using Arcus.Security.Core.Caching;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
-    //     this will get the 'serviceBusTopicConnectionStringSecretKey' string (configured below) and has to retrieve the connection string for the topic.
-    services.AddSingleton<ISecretProvider>(serviceProvider => ...);
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // An 'ISecretProvider' implementation (see: https://security.arcus-azure.net/) to access the Azure Service Bus Topic resource;
+        //     this will get the 'serviceBusTopicConnectionStringSecretKey' string (configured below) and has to retrieve the connection string for the topic.
+        services.AddSingleton<ISecretProvider>(serviceProvider => ...);
 
-    // An `ICachedSecretProvider` implementation which secret keys will automatically be invalidated.
-    services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(mySecretProvider));
+        // An `ICachedSecretProvider` implementation which secret keys will automatically be invalidated.
+        services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(mySecretProvider));
 
-    services.AddAutoInvalidateKeyVaultSecretBackgroundJob(
-        // Prefix of the Azure Service Bus Topic subscription;
-        //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
-        subscriptionNamePrefix: "MyPrefix"
+        services.AddAutoInvalidateKeyVaultSecretBackgroundJob(
+            // Prefix of the Azure Service Bus Topic subscription;
+            //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
+            subscriptionNamePrefix: "MyPrefix"
 
-        // Connection string secret key to a Azure Service Bus Topic.
-        serviceBusTopicConnectionStringSecretKey: "MySecretKeyToServiceBusTopicConnectionString");
+            // Connection string secret key to a Azure Service Bus Topic.
+            serviceBusTopicConnectionStringSecretKey: "MySecretKeyToServiceBusTopicConnectionString");
+    }
 }
 ```
 


### PR DESCRIPTION
Add missing `using' statements to the feature docs.

Relates to https://github.com/arcus-azure/arcus/issues/107