### PR TITLE
feat: move auto-restart az servicebus message pump on rotated credentials

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -29,6 +29,7 @@ resources:
 variables:
   - group: 'Arcus Background Jobs - Integration Testing'
   - group: 'Arcus Security - Integration Testing'
+  - group: 'Arcus Messaging - Integration Testing'
   - group: 'Arcus - GitHub Package Registry'
   - group: 'Build Configuration'
   - template: ./variables/build.yml

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -17,6 +17,7 @@ resources:
 variables:
   - group: 'Arcus Background Jobs - Integration Testing'
   - group: 'Arcus Security - Integration Testing'
+  - group: 'Arcus Messaging - Integration Testing'
   - group: 'Build Configuration'
   - group: 'Arcus Background Jobs - .NET'
   - template: ./variables/build.yml

--- a/docs/preview/features/security/auto-restart-servicebus-messagepump-on-rotated-credentials.md
+++ b/docs/preview/features/security/auto-restart-servicebus-messagepump-on-rotated-credentials.md
@@ -1,0 +1,60 @@
+---
+title: "Automatically restart Azure Service Bus message pump on rotated credentials"
+layout: default
+---
+
+# Automatic Azure Key Vault credentials rotation
+
+The library `Arcus.BackgroundJobs.KeyVault` provides an extension on the message pump to restart the pump automatically when the credentials of the pump stored in Azure Key Vault are changed.
+This feature allows more reliable restarting instead of relying on authentication exceptions that may be throwed during the lifetime of the message pump.
+
+## How does this work?
+
+A background job is polling for `SecretNewVersionCreated` events on an Azure Service Bus Topic for the secret that stores the connection string.
+
+That way, when the background job receives a new Key Vault event, it will get the latest connection string, restart the message pump and authenticate with the latest credentials.
+
+### Installation
+
+This features requires to install our NuGet package:
+
+```shell
+PM > Install-Package Arcus.BackgroundJobs.KeyVault
+```
+
+### Usage
+
+When the package is installed, you'll be able to use the extension in your application:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // You should have a unique Job ID to identity the message pump so the automatic process knows which pump to restart.
+        string jobId = Guid.NewGuid().ToString();
+    
+        string secretName = hostContext.Configuration["ARCUS_KEYVAULT_CONNECTIONSTRINGSECRETNAME"];
+        services.AddServiceBusQueueMessagePump(secretName, options => options.JobId =   
+                .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
+
+         // This extension will be available to you once you installed the package.
+         services.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+             jobId: jobId, 
+             subscriptionNamePrefix: "TestSub", 
+             
+             // The secret key where the Azure Service Bus Topic connection string is located that the background job will use to receive the Azure Key vault events.
+             serviceBusTopicConnectionStringSecretKey: "ARCUS_KEYVAULT_SECRETNEWVERSIONCREATED_CONNECTIONSTRING",
+             
+             // The secret key where the Azure Service Bus connection string is located that your target message pump uses.
+             // This secret key name will be used to check if the received Azure Key Vault event is from this secret or not.
+             messagePumpConnectionStringKey: secretName,
+    
+             // The maximum amount of thrown unauthorized exceptions that your message pump should allow before it should restart either way.
+             // This amount can be used to either wait for an Azure Key Vault event or rely on the thrown unauthorized exceptions.
+             maximumUnauthorizedExceptionsBeforeRestart: 5)
+    }
+}
+```

--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -21,6 +21,7 @@ For more granular packages we recommend reading the documentation.
     - [Securely Receive CloudEvents](features/cloudevent/receive-cloudevents-job)
 - **Security**
     - [Automatically invalidate cached secrets from Azure Key Vault](features/security/auto-invalidate-secrets)
+    - [Automatically restart Azure Service Bus message pump on rotated credentials](features/security/auto-restart-servicebus-messagepump-on-rotated-credentials)
 - **Databricks**
     - [Measure Databricks job run outcomes as metric](features/databricks/job-metrics)
     - [Interact with Databricks to gain insights](features/databricks/gain-insights)

--- a/src/Arcus.BackgroundJobs.KeyVault/Arcus.BackgroundJobs.KeyVault.csproj
+++ b/src/Arcus.BackgroundJobs.KeyVault/Arcus.BackgroundJobs.KeyVault.csproj
@@ -19,7 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Arcus.Security.Core" Version="[1.1.0,2.0.0)" />
+    <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="[0.6.0,1.0.0)" />
+    <PackageReference Include="Arcus.Security.Core" Version="[1.3.0,2.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.BackgroundJobs.KeyVault/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.BackgroundJobs.KeyVault/Extensions/IServiceCollectionExtensions.cs
@@ -1,9 +1,13 @@
-﻿using Arcus.BackgroundJobs.KeyVault;
+﻿using System;
+using System.Linq;
+using Arcus.BackgroundJobs.KeyVault;
+using Arcus.BackgroundJobs.KeyVault.Events;
 using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
 using Arcus.Messaging.Pumps.ServiceBus;
 using Arcus.Security.Core.Caching;
 using CloudNative.CloudEvents;
 using GuardNet;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
@@ -36,6 +40,59 @@ namespace Microsoft.Extensions.DependencyInjection
                 var logger = serviceProvider.GetRequiredService<ILogger<InvalidateKeyVaultSecretHandler>>();
                 return new InvalidateKeyVaultSecretHandler(cachedSecretProvider, logger);
             });
+
+            return services;
+        }
+        
+        /// <summary>
+        /// Adds a background job to the <see cref="IServiceCollection"/> to automatically restart a <see cref="AzureServiceBusMessagePump"/> with a specific <paramref name="jobId"/>
+        /// when the Azure Key Vault secret that holds the Azure Service Bus connection string was updated.
+        /// </summary>
+        /// <param name="services">The collection of services to add the job to.</param>
+        /// <param name="jobId">The unique background job ID to identify which message pump to restart.</param>
+        /// <param name="subscriptionNamePrefix">The name of the Azure Service Bus subscription that will be created to receive <see cref="CloudEvent"/>'s.</param>
+        /// <param name="serviceBusTopicConnectionStringSecretKey">The secret key that points to the Azure Service Bus Topic connection string.</param>
+        /// <param name="messagePumpConnectionStringKey">
+        ///     The secret key where the connection string credentials are located for the target message pump that needs to be auto-restarted.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="services"/> or the searched for <see cref="AzureServiceBusMessagePump"/> based on the given <paramref name="jobId"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.
+        /// </exception>
+        public static IServiceCollection AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+            this IServiceCollection services,
+            string jobId,
+            string subscriptionNamePrefix,
+            string serviceBusTopicConnectionStringSecretKey,
+            string messagePumpConnectionStringKey)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a collection of services to add the re-authentication background job");
+            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a non-blank job ID to identify the Azure Service Bus message pump which needs to restart");
+            Guard.NotNullOrWhitespace(subscriptionNamePrefix, nameof(subscriptionNamePrefix), "Requires a non-blank subscription name of the Azure Service Bus Topic subscription, to receive Azure Key Vault events");
+            Guard.NotNullOrWhitespace(serviceBusTopicConnectionStringSecretKey, nameof(serviceBusTopicConnectionStringSecretKey), "Requires a non-blank secret key that points to a Azure Service Bus Topic");
+            Guard.NotNullOrWhitespace(messagePumpConnectionStringKey, nameof(messagePumpConnectionStringKey), "Requires a non-blank secret key that points to the credentials that holds the connection string of the target message pump");
+
+            services.AddCloudEventBackgroundJob(subscriptionNamePrefix, serviceBusTopicConnectionStringSecretKey);
+            services.WithServiceBusMessageHandler<ReAuthenticateOnRotatedCredentialsMessageHandler, CloudEvent>(
+                messageBodyFilter: cloudEvent => cloudEvent?.GetPayload<SecretNewVersionCreated>() != null,
+                implementationFactory: serviceProvider =>
+                {
+                    AzureServiceBusMessagePump messagePump =
+                        serviceProvider.GetServices<IHostedService>()
+                                       .OfType<AzureServiceBusMessagePump>()
+                                       .FirstOrDefault(pump => pump.JobId == jobId);
+
+                    if (messagePump is null)
+                    {
+                        throw new InvalidOperationException(
+                            $"Cannot register re-authentication without a '{nameof(AzureServiceBusMessagePump)}' with 'JobId' = '{jobId}'");
+                    }
+
+                    var messageHandlerLogger = serviceProvider.GetRequiredService<ILogger<ReAuthenticateOnRotatedCredentialsMessageHandler>>();
+                    return new ReAuthenticateOnRotatedCredentialsMessageHandler(messagePumpConnectionStringKey, messagePump, messageHandlerLogger);
+                });
 
             return services;
         }

--- a/src/Arcus.BackgroundJobs.KeyVault/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.BackgroundJobs.KeyVault/Extensions/IServiceCollectionExtensions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     if (messagePump is null)
                     {
                         throw new InvalidOperationException(
-                            $"Cannot register re-authentication without a '{nameof(AzureServiceBusMessagePump)}' with 'JobId' = '{jobId}'");
+                            $"Cannot register re-authentication without a '{nameof(AzureServiceBusMessagePump)}' with job id {jobId}");
                     }
 
                     var messageHandlerLogger = serviceProvider.GetRequiredService<ILogger<ReAuthenticateOnRotatedCredentialsMessageHandler>>();

--- a/src/Arcus.BackgroundJobs.KeyVault/ReAuthenticateOnRotatedCredentialsMessageHandler.cs
+++ b/src/Arcus.BackgroundJobs.KeyVault/ReAuthenticateOnRotatedCredentialsMessageHandler.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.BackgroundJobs.KeyVault.Events;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Arcus.Messaging.Pumps.ServiceBus;
+using CloudNative.CloudEvents;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Rest.Azure;
+
+namespace Arcus.BackgroundJobs.KeyVault
+{
+    /// <summary>
+    /// Represents an <see cref="IMessageHandler{TMessage}"/> that processes <see cref="CloudEvent"/>s representing <see cref="SecretNewVersionCreated"/> events
+    /// that will eventually result in restarting an <see cref="AzureServiceBusMessagePump"/> instance.
+    /// </summary>
+    public class ReAuthenticateOnRotatedCredentialsMessageHandler : IAzureServiceBusMessageHandler<CloudEvent>
+    {
+        private readonly string _targetConnectionStringKey;
+        private readonly AzureServiceBusMessagePump _messagePump;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReAuthenticateOnRotatedCredentialsMessageHandler"/> class.
+        /// </summary>
+        /// <param name="targetConnectionStringKey">The secret key where the connection string credentials are located for the target message pump that needs to be auto-restarted.</param>
+        /// <param name="messagePump">The message pump instance to restart when the message handler process an <see cref="SecretNewVersionCreated"/> event.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messagePump"/> is <c>null</c>.</exception>
+        public ReAuthenticateOnRotatedCredentialsMessageHandler(
+            string targetConnectionStringKey, 
+            AzureServiceBusMessagePump messagePump)
+            : this(targetConnectionStringKey, messagePump, NullLogger<ReAuthenticateOnRotatedCredentialsMessageHandler>.Instance)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReAuthenticateOnRotatedCredentialsMessageHandler"/> class.
+        /// </summary>
+        /// <param name="targetConnectionStringKey">The secret key where the connection string credentials are located for the target message pump that needs to be auto-restarted.</param>
+        /// <param name="messagePump">The message pump instance to restart when the message handler process an <see cref="SecretNewVersionCreated"/> event.</param>
+        /// <param name="logger">The logger instance to write diagnostic trace messages during the processing of the event.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messagePump"/> or <paramref name="logger"/> is <c>null</c>.</exception>
+        public ReAuthenticateOnRotatedCredentialsMessageHandler(
+            string targetConnectionStringKey, 
+            AzureServiceBusMessagePump messagePump, 
+            ILogger<ReAuthenticateOnRotatedCredentialsMessageHandler> logger)
+        {
+            Guard.NotNullOrWhitespace(targetConnectionStringKey, nameof(targetConnectionStringKey), "Requires a non-blank secret key that points to the credentials that holds the connection string of the target message pump");
+            Guard.NotNull(messagePump, nameof(messagePump), $"Requires an message pump instance to restart when the message handler process an {nameof(SecretNewVersionCreated)} event");
+            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to write diagnostic trace messages during the processing of the event");
+
+            _targetConnectionStringKey = targetConnectionStringKey;
+            _messagePump = messagePump;
+            _logger = logger;
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="CloudException">Thrown when the <paramref name="message"/> doesn't represent an <see cref="SecretNewVersionCreated"/> event.</exception>
+        public async Task ProcessMessageAsync(
+            CloudEvent message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            Guard.NotNull(message, nameof(message), "Cannot invalidate Azure KeyVault secret from a 'null' CloudEvent");
+
+            _logger.LogTrace("Receiving new Azure Key Vault notification...");
+            
+            var secretNewVersionCreated = message.GetPayload<SecretNewVersionCreated>();
+            if (secretNewVersionCreated is null)
+            {
+                _logger.LogWarning("Azure Key Vault job cannot map Event Grid event to CloudEvent because the event data isn't recognized as a 'SecretNewVersionCreated' schema");
+            }
+            else
+            {
+                if (_targetConnectionStringKey == secretNewVersionCreated.ObjectName)
+                {
+                    _logger.LogTrace("Received Azure Key vault 'Secret New Version Created' event, restarting target message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}'", _messagePump.JobId, _messagePump.EntityPath, _messagePump.Namespace);
+                    await _messagePump.RestartAsync();
+                    _logger.LogEvent("Message pump restarted", new Dictionary<string, object>
+                    {
+                        ["JobId"] = _messagePump.JobId,
+                        ["EntityPath"] = _messagePump.EntityPath,
+                        ["Namespace"] = _messagePump.Namespace
+                    });
+                }
+                else
+                {
+                    _logger.LogTrace("Received Azure Key Vault 'Secret New Version Created' event for another secret, ignoring.");
+                }
+            }
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Arcus.BackgroundJobs.Tests.Integration.csproj
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Arcus.BackgroundJobs.Tests.Integration.csproj
@@ -6,14 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.0.0" />
+    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.3.0" />
-    <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0-preview-1" />
+    <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0-preview-2" />
+    <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/KeyVault/KeyRotationConfig.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/KeyVault/KeyRotationConfig.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus;
+using GuardNet;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.KeyVault
+{
+    /// <summary>
+    /// Represents all the configuration values related to testing key rotation.
+    /// </summary>
+    public class KeyRotationConfig
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyRotationConfig" /> class.
+        /// </summary>
+        /// <param name="keyVault">The config to represent a Azure Key Vault secret.</param>
+        /// <param name="servicePrincipal">The config to authenticate to Azure resources.</param>
+        /// <param name="serviceBusNamespace">The config to represent a Azure Service Bus namespace.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="keyVault"/>, <paramref name="servicePrincipal"/>, or <paramref name="serviceBusNamespace"/> is <c>null</c>.
+        /// </exception>
+        public KeyRotationConfig(KeyVaultConfig keyVault, ServicePrincipal servicePrincipal, ServiceBusNamespace serviceBusNamespace)
+        {
+            Guard.NotNull(keyVault, nameof(keyVault));
+            Guard.NotNull(servicePrincipal, nameof(servicePrincipal));
+            Guard.NotNull(serviceBusNamespace, nameof(serviceBusNamespace));
+
+            KeyVault = keyVault;
+            ServicePrincipal = servicePrincipal;
+            ServiceBusNamespace = serviceBusNamespace;
+        }
+
+        /// <summary>
+        /// Gets the config representing a Azure Key Vault secret.
+        /// </summary>
+        public KeyVaultConfig KeyVault { get; }
+
+        /// <summary>
+        /// Gets the config to authenticate to Azure resources.
+        /// </summary>
+        public ServicePrincipal ServicePrincipal { get; }
+
+        /// <summary>
+        /// Gets the config to represent a Azure Service Bus Queue.
+        /// </summary>
+        public ServiceBusNamespace ServiceBusNamespace { get; }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/KeyVault/KeyVaultConfig.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/KeyVault/KeyVaultConfig.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using GuardNet;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.KeyVault
+{
+    /// <summary>
+    /// Represents a secret inside an Azure Key Vault instance.
+    /// </summary>
+    public class KeyVaultConfig
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyVaultConfig" /> class.
+        /// </summary>
+        /// <param name="vaultUri">The URI referencing the Azure Key Vault instance.</param>
+        /// <param name="secretName">The name of the secret in the Azure Key Vault instance.</param>
+        /// <param name="secretNewVersionCreated">The event endpoint of the Azure Key Vault 'Secret new version created' event.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="vaultUri"/> or <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretNewVersionCreated"/> is <c>null</c>.</exception>
+        public KeyVaultConfig(string vaultUri, string secretName, KeyVaultEventEndpoint secretNewVersionCreated)
+        {
+            Guard.NotNullOrWhitespace(vaultUri, nameof(vaultUri));
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName));
+            Guard.NotNull(secretNewVersionCreated, nameof(secretNewVersionCreated));
+
+            VaultUri = vaultUri;
+            SecretName = secretName;
+            SecretNewVersionCreated = secretNewVersionCreated;
+        }
+
+        /// <summary>
+        /// Gets the URI referencing the Azure Key Vault instance.
+        /// </summary>
+        public string VaultUri { get; }
+
+        /// <summary>
+        /// Gets the name of the secret in the Azure Key Vault instance.
+        /// </summary>
+        public string SecretName { get; }
+
+        /// <summary>
+        /// Gets the endpoint where Azure Key Vault events will be available, including 'Secret new version created' event.
+        /// </summary>
+        public KeyVaultEventEndpoint SecretNewVersionCreated { get; }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/KeyVault/KeyVaultEventEndpoint.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/KeyVault/KeyVaultEventEndpoint.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using GuardNet;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.KeyVault
+{
+    /// <summary>
+    /// Represents an endpoint where an Azure Key Vault event will be send to.
+    /// </summary>
+    public class KeyVaultEventEndpoint
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyVaultEventEndpoint"/> class.
+        /// </summary>
+        /// <param name="connectionString">The connection string to connect to the endpoint that will handle the Azure Key Vault event.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        public KeyVaultEventEndpoint(string connectionString)
+        {
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString));
+
+            ConnectionString = connectionString;
+        }
+
+        /// <summary>
+        /// Gets the connection string to connect to the endpoint that will handle the Azure Key Vault event.
+        /// </summary>
+        public string ConnectionString { get; }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/Customer.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/Customer.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus
+{
+    public class Customer
+    {
+        [JsonProperty]
+        public string FirstName { get; private set; }
+
+        [JsonProperty]
+        public string LastName { get; private set; }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/Order.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/Order.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus
+{
+    public class Order
+    {
+        [JsonProperty]
+        public string Id { get; set; }
+
+        [JsonProperty]
+        public int Amount { get; set; }
+
+        [JsonProperty]
+        public string ArticleNumber { get; set; }
+
+        [JsonProperty]
+        public Customer Customer { get; set; }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/OrderCreatedEventData.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/OrderCreatedEventData.cs
@@ -1,0 +1,22 @@
+﻿using Arcus.Messaging.Abstractions;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus
+{
+    public class OrderCreatedEventData
+    {
+        public OrderCreatedEventData(string id, int amount, string articleNumber, string customerName, MessageCorrelationInfo correlationInfo)
+        {
+            Id = id;
+            Amount = amount;
+            ArticleNumber = articleNumber;
+            CustomerName = customerName;
+            CorrelationInfo = correlationInfo;
+        }
+
+        public string Id { get; set; }
+        public int Amount { get; set; }
+        public string ArticleNumber { get; set; }
+        public string CustomerName { get; set; }
+        public MessageCorrelationInfo CorrelationInfo { get; set; }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/OrdersAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/OrdersAzureServiceBusMessageHandler.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Net.Mime;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.EventGrid.Publishing.Interfaces;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using CloudNative.CloudEvents;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus
+{
+    public class OrdersAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Order>
+    {
+        private readonly IEventGridPublisher _eventGridPublisher;
+        private readonly ILogger<OrdersAzureServiceBusMessageHandler> _logger;
+
+        public OrdersAzureServiceBusMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrdersAzureServiceBusMessageHandler> logger)
+        {
+            Guard.NotNull(eventGridPublisher, nameof(eventGridPublisher));
+            Guard.NotNull(logger, nameof(logger));
+
+            _eventGridPublisher = eventGridPublisher;
+            _logger = logger;
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="order">Message that was received</param>
+        /// <param name="azureMessageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public async Task ProcessMessageAsync(
+            Order order,
+            AzureServiceBusMessageContext azureMessageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", 
+                                   order.Id, order.Amount, order.ArticleNumber, order.Customer.FirstName, order.Customer.LastName);
+
+            await PublishEventToEventGridAsync(order, correlationInfo.OperationId, correlationInfo);
+
+            _logger.LogInformation("Order {OrderId} processed", order.Id);
+        }
+
+        private async Task PublishEventToEventGridAsync(Order orderMessage, string operationId, MessageCorrelationInfo correlationInfo)
+        {
+            var eventData = new OrderCreatedEventData(
+                orderMessage.Id,
+                orderMessage.Amount,
+                orderMessage.ArticleNumber,
+                $"{orderMessage.Customer.FirstName} {orderMessage.Customer.LastName}",
+                correlationInfo);
+
+            var orderCreatedEvent = new CloudEvent(
+                CloudEventsSpecVersion.V1_0,
+                "OrderCreatedEvent",
+                new Uri("http://test-host"),
+                operationId,
+                DateTime.UtcNow)
+            {
+                Data = eventData,
+                DataContentType = new ContentType("application/json")
+            };
+
+            await _eventGridPublisher.PublishAsync(orderCreatedEvent);
+
+            _logger.LogInformation("Event {EventId} was published with subject {EventSubject}", orderCreatedEvent.Id, orderCreatedEvent.Subject);
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/ServiceBusConfiguration.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/ServiceBusConfiguration.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Threading.Tasks;
+using Arcus.BackgroundJobs.Tests.Integration.Fixture.KeyVault;
+using GuardNet;
+using Microsoft.Azure.Management.ServiceBus;
+using Microsoft.Azure.Management.ServiceBus.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Rest;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus
+{
+    /// <summary>
+    /// Represents the test client to interact with a Azure Service Bus resource.
+    /// </summary>
+    public class ServiceBusConfiguration
+    {
+        private readonly KeyRotationConfig _configuration;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBusConfiguration"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration instance to provide the necessary information during authentication with the correct Azure Service Bus instance.</param>
+        /// <param name="logger">The instance to log diagnostic messages during the interaction with the Azure Service Bus instance.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/> or the <paramref name="logger"/> is <c>null</c>.</exception>
+        public ServiceBusConfiguration(KeyRotationConfig configuration, ILogger logger)
+        {
+            Guard.NotNull(configuration, nameof(configuration));
+            Guard.NotNull(logger, nameof(logger));
+
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Gets the connection string keys for the Azure Service Bus Topic tested in the integration test suite.
+        /// </summary>
+        public async Task<AccessKeys> GetConnectionStringKeysForTopicAsync()
+        {
+            using IServiceBusManagementClient client = await CreateServiceManagementClientAsync();
+
+            AccessKeys accessKeys = await client.Topics.ListKeysAsync(
+                _configuration.ServiceBusNamespace.ResourceGroup,
+                _configuration.ServiceBusNamespace.Namespace,
+                _configuration.ServiceBusNamespace.TopicName,
+                _configuration.ServiceBusNamespace.AuthorizationRuleName);
+
+            return accessKeys;
+        }
+
+        /// <summary>
+        /// Rotates the connection string key of the Azure Service Bus Queue, returning the new connection string as result.
+        /// </summary>
+        /// <param name="keyType">The type of key to rotate.</param>
+        /// <returns>
+        ///     The new connection string according to the <paramref name="keyType"/>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="keyType"/> is not within the bounds of the enumration.</exception>
+        public async Task<string> RotateConnectionStringKeysForQueueAsync(KeyType keyType)
+        {
+            Guard.For<ArgumentOutOfRangeException>(
+                () => !Enum.IsDefined(typeof(KeyType), keyType),
+                $"Requires a KeyType that is either '{nameof(KeyType.PrimaryKey)}' or '{nameof(KeyType.SecondaryKey)}'");
+
+            var parameters = new RegenerateAccessKeyParameters(keyType);
+            string queueName = _configuration.ServiceBusNamespace.QueueName;
+            const ServiceBusEntityType entity = ServiceBusEntityType.Queue;
+
+            try
+            {
+                using IServiceBusManagementClient client = await CreateServiceManagementClientAsync();
+                
+                _logger.LogTrace(
+                    "Start rotating {KeyType} connection string of Azure Service Bus {EntityType} '{EntityName}'...",
+                    keyType, entity, queueName);
+
+                AccessKeys accessKeys = await client.Queues.RegenerateKeysAsync(
+                    _configuration.ServiceBusNamespace.ResourceGroup,
+                    _configuration.ServiceBusNamespace.Namespace,
+                    queueName,
+                    _configuration.ServiceBusNamespace.AuthorizationRuleName,
+                    parameters);
+
+                _logger.LogInformation(
+                        "Rotated {KeyType} connection string of Azure Service Bus {EntityType} '{EntityName}'",
+                        keyType, entity, queueName);
+
+                switch (keyType)
+                {
+                    case KeyType.PrimaryKey:   return accessKeys.PrimaryConnectionString;
+                    case KeyType.SecondaryKey: return accessKeys.SecondaryConnectionString;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(keyType), keyType, "Unknown key type");
+                }
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(
+                    exception, "Failed to rotate the {KeyType} connection string of the Azure Service Bus {EntityType} '{EntityName}'", keyType, entity, queueName);
+                
+                throw;
+            }
+        }
+
+        private async Task<IServiceBusManagementClient> CreateServiceManagementClientAsync()
+        {
+            string tenantId = _configuration.ServiceBusNamespace.TenantId;
+            var context = new AuthenticationContext($"https://login.microsoftonline.com/{tenantId}");
+
+            ClientCredential clientCredentials = _configuration.ServicePrincipal.CreateCredentials();
+            AuthenticationResult result =
+                await context.AcquireTokenAsync(
+                    "https://management.azure.com/",
+                    clientCredentials);
+
+            var tokenCredentials = new TokenCredentials(result.AccessToken);
+            string subscriptionId = _configuration.ServiceBusNamespace.SubscriptionId;
+
+            var client = new ServiceBusManagementClient(tokenCredentials) { SubscriptionId = subscriptionId };
+            return client;
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/ServiceBusNamespace.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/ServiceBusNamespace.cs
@@ -1,0 +1,81 @@
+﻿using GuardNet;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus
+{
+    /// <summary>
+    /// Represents the configuration values related to an Azure Service Bus instance.
+    /// </summary>
+    public class ServiceBusNamespace
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBusNamespace" /> class.
+        /// </summary>
+        /// <param name="tenantId">The ID of the tenant on which the Azure instance is run.</param>
+        /// <param name="azureSubscriptionId">The ID of the Azure subscription.</param>
+        /// <param name="resourceGroup">The name of the resource group where the Azure Service Bus is located.</param>
+        /// <param name="namespace">The namespace in which the Azure Service Bus is categorized.</param>
+        /// <param name="queueName">The name of the Queue in the Azure Service Bus instance.</param>
+        /// <param name="topicName">The name of the Topic in the Azure Service Bus instance.</param>
+        /// <param name="authorizationRuleName">The name of the authorization rule that describes the available permissions.</param>
+        public ServiceBusNamespace(
+            string tenantId,
+            string azureSubscriptionId,
+            string resourceGroup,
+            string @namespace,
+            string queueName,
+            string topicName,
+            string authorizationRuleName)
+        {
+            Guard.NotNullOrWhitespace(azureSubscriptionId, nameof(azureSubscriptionId));
+            Guard.NotNullOrWhitespace(tenantId, nameof(azureSubscriptionId));
+            Guard.NotNullOrWhitespace(resourceGroup, nameof(resourceGroup));
+            Guard.NotNullOrWhitespace(@namespace, nameof(@namespace));
+            Guard.NotNullOrWhitespace(queueName, nameof(queueName));
+            Guard.NotNullOrWhitespace(topicName, nameof(topicName));
+            Guard.NotNullOrWhitespace(authorizationRuleName, nameof(authorizationRuleName));
+
+            SubscriptionId = azureSubscriptionId;
+            TenantId = tenantId;
+            ResourceGroup = resourceGroup;
+            Namespace = @namespace;
+            QueueName = queueName;
+            TopicName = topicName;
+            AuthorizationRuleName = authorizationRuleName;
+        }
+
+        /// <summary>
+        /// Gets the ID of the tenant on which the Azure instance is run.
+        /// </summary>
+        public string TenantId { get; }
+
+        /// <summary>
+        /// Gets the ID of the Azure subscription.
+        /// </summary>
+        public string SubscriptionId { get; }
+
+        /// <summary>
+        /// Gets the name of the resource group where the Azure Service Bus is located.
+        /// </summary>
+        public string ResourceGroup { get; }
+
+        /// <summary>
+        /// Gets the namespace in which the Azure Service Bus is categorized.
+        /// </summary>
+        public string Namespace { get; }
+
+        /// <summary>
+        /// Gets the name of the Queue in the Azure Service Bus namespace.
+        /// </summary>
+        public string QueueName { get; }
+
+        /// <summary>
+        /// Gets the name of the Topic in the Azure Service Bus namespace.
+        /// </summary>
+        public string TopicName { get; }
+
+        /// <summary>
+        /// Gets the name of the authorization rule that describes the available permissions.
+        /// </summary>
+        public string AuthorizationRuleName { get; }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServicePrincipal.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServicePrincipal.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Arcus.Security.Providers.AzureKeyVault.Authentication;
+using GuardNet;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture
+{
+    /// <summary>
+    /// Represents a registered service principal that can authenticate to Azure resources.
+    /// </summary>
+    public class ServicePrincipal
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServicePrincipal"/> class.
+        /// </summary>
+        /// <param name="clientId">The ID of the client application.</param>
+        /// <param name="clientSecret">The secret of the client application.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="clientId"/> or <paramref name="clientSecret"/> is blank.</exception>
+        public ServicePrincipal(string clientId, string clientSecret)
+        {
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank Azure service principal client ID");
+            Guard.NotNullOrWhitespace(clientSecret, nameof(clientSecret), "Requires a non-blank Azure service principal client secret");
+
+            ClientId = clientId;
+            ClientSecret = clientSecret;
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServicePrincipal"/> class.
+        /// </summary>
+        /// <param name="clientId">The ID of the client application.</param>
+        /// <param name="clientSecret">The secret of the client application.</param>
+        /// <param name="clientSecretKey">The key to the secret of the client application.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="clientId"/>, <paramref name="clientSecret"/> or <paramref name="clientSecretKey"/> is blank.</exception>
+        public ServicePrincipal(string clientId, string clientSecret, string clientSecretKey)
+        {
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank Azure service principal client ID");
+            Guard.NotNullOrWhitespace(clientSecret, nameof(clientSecret), "Requires a non-blank Azure service principal client secret");
+            Guard.NotNullOrWhitespace(clientSecretKey, nameof(clientSecretKey), "Requires a non-blank secret Azure Key Vault key where the Azure service principal client secret is located");
+
+            ClientId = clientId;
+            ClientSecret = clientSecret;
+            ClientSecretKey = clientSecretKey;
+        }
+
+        /// <summary>
+        /// Gets the ID of the client application.
+        /// </summary>
+        public string ClientId { get; }
+
+        /// <summary>
+        /// Gets the secret of the client application.
+        /// </summary>
+        public string ClientSecret { get; }
+
+        /// <summary>
+        /// Gets the key to the client secret of the client application.
+        /// </summary>
+        public string ClientSecretKey { get; }
+
+        /// <summary>
+        /// Creates an instance to authenticate to Azure Key Vault.
+        /// </summary>
+        public ServicePrincipalAuthentication CreateAuthentication()
+        {
+            return new ServicePrincipalAuthentication(ClientId, ClientSecret);
+        }
+
+        /// <summary>
+        /// Creates an instance that combines the service principal information into an <see cref="ClientCredential"/> instance.
+        /// </summary>
+        public ClientCredential CreateCredentials()
+        {
+            return new ClientCredential(ClientId, ClientSecret);
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Hosting/ServiceBus/TestMessagePumpService.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Hosting/ServiceBus/TestMessagePumpService.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Threading.Tasks;
+using Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus;
+using Arcus.EventGrid;
+using Arcus.EventGrid.Contracts;
+using Arcus.EventGrid.Parsers;
+using Arcus.EventGrid.Testing.Infrastructure.Hosts.ServiceBus;
+using Bogus;
+using GuardNet;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Hosting.ServiceBus
+{
+    /// <summary>
+    /// Represents a service to interact with the hosted-service.
+    /// </summary>
+    public class TestMessagePumpService : IAsyncDisposable
+    {
+        private readonly ILogger _logger;
+        private readonly TestConfig _configuration;
+
+        private ServiceBusEventConsumerHost _serviceBusEventConsumerHost;
+
+        private TestMessagePumpService(TestConfig configuration, ILogger logger)
+        {
+            Guard.NotNull(configuration, nameof(configuration));
+            Guard.NotNull(logger, nameof(logger));
+
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Starts a new instance of the <see cref="TestMessagePumpService"/> type to simulate messages.
+        /// </summary>
+        /// <param name="config">The configuration instance to retrieve the Azure Service Bus test infrastructure authentication information.</param>
+        /// <param name="logger">The instance to log diagnostic messages during the interaction with teh Azure Service Bus test infrastructure.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="config"/> or the <paramref name="logger"/> is <c>null</c>.</exception>
+        public static async Task<TestMessagePumpService> StartNewAsync(
+            TestConfig config,
+            ILogger logger)
+        {
+            Guard.NotNull(config, nameof(config));
+            Guard.NotNull(logger, nameof(logger));
+
+            var service = new TestMessagePumpService(config, logger);
+            await service.StartAsync();
+
+            return service;
+        }
+
+        private async Task StartAsync()
+        {
+            if (_serviceBusEventConsumerHost is null)
+            {
+                var topicName = _configuration.GetValue<string>("Arcus:Infra:ServiceBus:TopicName");
+                var connectionString = _configuration.GetValue<string>("Arcus:Infra:ServiceBus:ConnectionString");
+                var serviceBusEventConsumerHostOptions = new ServiceBusEventConsumerHostOptions(topicName, connectionString);
+
+                _serviceBusEventConsumerHost = await ServiceBusEventConsumerHost.StartAsync(serviceBusEventConsumerHostOptions, _logger);
+            }
+            else
+            {
+                throw new InvalidOperationException("Service is already started!");
+            }
+        }
+
+        /// <summary>
+        /// Simulate the message processing of the message pump using the Azure Service Bus.
+        /// </summary>
+        /// <param name="connectionString">The connection string used to send a Azure Service Bus message to the respectively running message pump.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
+        public async Task SimulateMessageProcessingAsync(string connectionString)
+        {
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString));
+
+            if (_serviceBusEventConsumerHost is null)
+            {
+                throw new InvalidOperationException(
+                    "Cannot simulate the message pump because the service is not yet started; please start this service before simulating");
+            }
+
+            var operationId = Guid.NewGuid().ToString();
+            var transactionId = Guid.NewGuid().ToString();
+
+            Order order = GenerateOrder();
+            Message orderMessage = order.AsServiceBusMessage(operationId, transactionId);
+            orderMessage.UserProperties["Topic"] = "Orders";
+            await SendMessageToServiceBusAsync(connectionString, orderMessage);
+
+            string receivedEvent = _serviceBusEventConsumerHost.GetReceivedEvent(operationId, retryCount: 10);
+            Assert.NotEmpty(receivedEvent);
+
+            EventBatch<Event> eventBatch = EventParser.Parse(receivedEvent);
+            Assert.NotNull(eventBatch);
+            Event orderCreatedEvent = Assert.Single(eventBatch.Events);
+            Assert.NotNull(orderCreatedEvent);
+
+            var orderCreatedEventData = orderCreatedEvent.GetPayload<OrderCreatedEventData>();
+            Assert.NotNull(orderCreatedEventData);
+            Assert.NotNull(orderCreatedEventData.CorrelationInfo);
+            Assert.Equal(order.Id, orderCreatedEventData.Id);
+            Assert.Equal(order.Amount, orderCreatedEventData.Amount);
+            Assert.Equal(order.ArticleNumber, orderCreatedEventData.ArticleNumber);
+            Assert.Equal(transactionId, orderCreatedEventData.CorrelationInfo.TransactionId);
+            Assert.Equal(operationId, orderCreatedEventData.CorrelationInfo.OperationId);
+            Assert.NotEmpty(orderCreatedEventData.CorrelationInfo.CycleId);
+        }
+        
+        public static Order GenerateOrder()
+        {
+            var customerGenerator = new Faker<Customer>()
+                .RuleFor(u => u.FirstName, (f, u) => f.Name.FirstName())
+                .RuleFor(u => u.LastName, (f, u) => f.Name.LastName());
+
+            var orderGenerator = new Faker<Order>()
+                .RuleFor(u => u.Customer, () => customerGenerator)
+                .RuleFor(u => u.Id, f => Guid.NewGuid().ToString())
+                .RuleFor(u => u.Amount, f => f.Random.Int())
+                .RuleFor(u => u.ArticleNumber, f => f.Commerce.Product());
+
+            return orderGenerator.Generate();
+        }
+
+        /// <summary>
+        /// Sends an Azure Service Bus message to the message pump.
+        /// </summary>
+        /// <param name="connectionString">The connection string to connect to the service bus.</param>
+        /// <param name="message">The message to send.</param>
+        public async Task SendMessageToServiceBusAsync(string connectionString, Message message)
+        {
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString));
+
+            var serviceBusConnectionStringBuilder = new ServiceBusConnectionStringBuilder(connectionString);
+            var messageSender = new MessageSender(serviceBusConnectionStringBuilder);
+
+            try
+            {
+                await messageSender.SendAsync(message);
+            }
+            finally
+            {
+                await messageSender.CloseAsync();
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous dispose operation.</returns>
+        public async ValueTask DisposeAsync()
+        {
+            if (_serviceBusEventConsumerHost != null)
+            {
+                await _serviceBusEventConsumerHost.StopAsync();
+            }
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Hosting/Worker.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Hosting/Worker.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using GuardNet;
+using Microsoft.Extensions.Hosting;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Hosting
+{
+    /// <summary>
+    /// Represents a test worker implementation of a .NET SDK worker project, which includes all the options available in a worker project.
+    /// Used to test message pumps and other messaging-related components that requires the hosted services setup.
+    /// </summary>
+    public class Worker : IAsyncDisposable
+    {
+        private readonly IHost _host;
+        private readonly string _testName;
+        
+        private Worker(IHost host, string testName)
+        {
+            _host = host;
+            _testName = testName;
+        }
+
+        /// <summary>
+        /// Spawns a new test worker configurable with <paramref name="options"/>.
+        /// </summary>
+        /// <param name="options">The configurable options to influence the content of the test worker.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> or <paramref name="logger"/> is <c>null</c>.</exception>
+        public static async Task<Worker> StartNewAsync(WorkerOptions options, [CallerMemberName] string memberName = null)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a options instance that influence the test worker implementation");
+            
+            Console.WriteLine("Start '{0}' integration test", memberName);
+            
+            IHostBuilder hostBuilder = Host.CreateDefaultBuilder();
+            options.ApplyOptions(hostBuilder);
+            IHost host = hostBuilder.Build();
+            
+            var worker = new Worker(host, memberName);
+            await worker._host.StartAsync();
+            return worker;
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous dispose operation.</returns>
+        public async ValueTask DisposeAsync()
+        {
+            Console.WriteLine("Stop '{0}' integration test", _testName);
+
+            try
+            {
+                await _host.StopAsync();
+                _host.Dispose();
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignore.
+            }
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Hosting/WorkerOptions.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Hosting/WorkerOptions.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Arcus.Testing.Logging;
+using GuardNet;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Hosting
+{
+    /// <summary>
+    /// Represents the configurable options to influence the test <see cref="Worker"/>.
+    /// </summary>
+    public class WorkerOptions : IServiceCollection
+    {
+        private readonly ICollection<Action<IHostBuilder>> _additionalHostOptions = new Collection<Action<IHostBuilder>>();
+        
+        /// <summary>
+        /// Gets the services that will be included in the test <see cref="Worker"/>.
+        /// </summary>
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        /// <summary>
+        /// Gets the configuration instance that will be included in the test <see cref="Worker"/> and which will result in an <see cref="IConfiguration"/> instance.
+        /// </summary>
+        public IDictionary<string, string> Configuration { get; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Adds an additional configuration option on the to-be-created <see cref="IHostBuilder"/>.
+        /// </summary>
+        /// <param name="additionalHostOption">The action that configures the additional option.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="additionalHostOption"/> is <c>null</c>.</exception>
+        public WorkerOptions Configure(Action<IHostBuilder> additionalHostOption)
+        {
+            Guard.NotNull(additionalHostOption, nameof(additionalHostOption), "Requires an custom action that will add the additional hosting option");
+            _additionalHostOptions.Add(additionalHostOption);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a <paramref name="logger"/> to the test worker instance to write diagnostic trace messages to the test output.
+        /// </summary>
+        /// <param name="logger">The test logger to write the diagnostic trace messages to.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        public WorkerOptions ConfigureLogging(ILogger logger)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write diagnostic trace messages to the test output");
+
+            _additionalHostOptions.Add(hostBuilder =>
+            {
+                hostBuilder.ConfigureLogging(logging =>
+                {
+                    logging.AddProvider(new CustomLoggerProvider(logger))
+                           .SetMinimumLevel(LogLevel.Trace);
+                });
+            });
+            
+            return this;
+        }
+
+        /// <summary>
+        /// Applies the previously configured additional host options to the given <paramref name="hostBuilder"/>.
+        /// </summary>
+        /// <param name="hostBuilder">The builder instance to apply the additional host options to.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="hostBuilder"/> is <c>null</c>.</exception>
+        internal void ApplyOptions(IHostBuilder hostBuilder)
+        {
+            Guard.NotNull(hostBuilder, nameof(hostBuilder), "Requires a host builder instance to apply the worker options to");
+            
+            hostBuilder.ConfigureAppConfiguration(config => config.AddInMemoryCollection(Configuration))
+                       .ConfigureServices(services =>
+                       {
+                           foreach (ServiceDescriptor service in Services)
+                           {
+                               services.Add(service);
+                           }
+                       });
+
+            hostBuilder.ConfigureLogging(logging => logging.ClearProviders());
+            
+            foreach (Action<IHostBuilder> additionalHostOption in _additionalHostOptions)
+            {
+                additionalHostOption(hostBuilder);
+            }
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<ServiceDescriptor> GetEnumerator()
+        {
+            return Services.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable) Services).GetEnumerator();
+        }
+
+        /// <summary>
+        /// Adds an item to the <see cref="T:System.Collections.Generic.ICollection`1" />.
+        /// </summary>
+        /// <param name="item">The object to add to the <see cref="T:System.Collections.Generic.ICollection`1" />.</param>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.</exception>
+        public void Add(ServiceDescriptor item)
+        {
+            Services.Add(item);
+        }
+
+        /// <summary>
+        /// Removes all items from the <see cref="T:System.Collections.Generic.ICollection`1" />.
+        /// </summary>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.</exception>
+        public void Clear()
+        {
+            Services.Clear();
+        }
+
+        /// <summary>
+        /// Determines whether the <see cref="T:System.Collections.Generic.ICollection`1" /> contains a specific value.
+        /// </summary>
+        /// <param name="item">The object to locate in the <see cref="T:System.Collections.Generic.ICollection`1" />.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="item" /> is found in the <see cref="T:System.Collections.Generic.ICollection`1" />; otherwise, <see langword="false" />.</returns>
+        public bool Contains(ServiceDescriptor item)
+        {
+            return Services.Contains(item);
+        }
+
+        /// <summary>
+        /// Copies the elements of the <see cref="T:System.Collections.Generic.ICollection`1" /> to an <see cref="T:System.Array" />, starting at a particular <see cref="T:System.Array" /> index.
+        /// </summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the elements copied from <see cref="T:System.Collections.Generic.ICollection`1" />. The <see cref="T:System.Array" /> must have zero-based indexing.</param>
+        /// <param name="arrayIndex">The zero-based index in <paramref name="array" /> at which copying begins.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        /// <paramref name="array" /> is <see langword="null" />.</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <paramref name="arrayIndex" /> is less than 0.</exception>
+        /// <exception cref="T:System.ArgumentException">The number of elements in the source <see cref="T:System.Collections.Generic.ICollection`1" /> is greater than the available space from <paramref name="arrayIndex" /> to the end of the destination <paramref name="array" />.</exception>
+        public void CopyTo(ServiceDescriptor[] array, int arrayIndex)
+        {
+            Services.CopyTo(array, arrayIndex);
+        }
+
+        /// <summary>Removes the first occurrence of a specific object from the <see cref="T:System.Collections.Generic.ICollection`1" />.</summary>
+        /// <param name="item">The object to remove from the <see cref="T:System.Collections.Generic.ICollection`1" />.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="item" /> was successfully removed from the <see cref="T:System.Collections.Generic.ICollection`1" />; otherwise, <see langword="false" />. This method also returns <see langword="false" /> if <paramref name="item" /> is not found in the original <see cref="T:System.Collections.Generic.ICollection`1" />.</returns>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.</exception>
+        public bool Remove(ServiceDescriptor item)
+        {
+            return Services.Remove(item);
+        }
+
+        /// <summary>
+        /// Gets the number of elements contained in the <see cref="T:System.Collections.Generic.ICollection`1" />.
+        /// </summary>
+        /// <returns>The number of elements contained in the <see cref="T:System.Collections.Generic.ICollection`1" />.</returns>
+        public int Count => Services.Count;
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true" /> if the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only; otherwise, <see langword="false" />.</returns>
+        public bool IsReadOnly => Services.IsReadOnly;
+
+        /// <summary>
+        /// Determines the index of a specific item in the <see cref="T:System.Collections.Generic.IList`1" />.
+        /// </summary>
+        /// <param name="item">The object to locate in the <see cref="T:System.Collections.Generic.IList`1" />.</param>
+        /// <returns>The index of <paramref name="item" /> if found in the list; otherwise, -1.</returns>
+        public int IndexOf(ServiceDescriptor item)
+        {
+            return Services.IndexOf(item);
+        }
+
+        /// <summary>
+        /// Inserts an item to the <see cref="T:System.Collections.Generic.IList`1" /> at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index at which <paramref name="item" /> should be inserted.</param>
+        /// <param name="item">The object to insert into the <see cref="T:System.Collections.Generic.IList`1" />.</param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <paramref name="index" /> is not a valid index in the <see cref="T:System.Collections.Generic.IList`1" />.</exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.IList`1" /> is read-only.</exception>
+        public void Insert(int index, ServiceDescriptor item)
+        {
+            Services.Insert(index, item);
+        }
+
+        /// <summary>
+        /// Removes the <see cref="T:System.Collections.Generic.IList`1" /> item at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the item to remove.</param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <paramref name="index" /> is not a valid index in the <see cref="T:System.Collections.Generic.IList`1" />.</exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.IList`1" /> is read-only.</exception>
+        public void RemoveAt(int index)
+        {
+            Services.RemoveAt(index);
+        }
+
+        /// <summary>
+        /// Gets or sets the element at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to get or set.</param>
+        /// <returns>The element at the specified index.</returns>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <paramref name="index" /> is not a valid index in the <see cref="T:System.Collections.Generic.IList`1" />.</exception>
+        /// <exception cref="T:System.NotSupportedException">The property is set and the <see cref="T:System.Collections.Generic.IList`1" /> is read-only.</exception>
+        public ServiceDescriptor this[int index]
+        {
+            get => Services[index];
+            set => Services[index] = value;
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Jobs/AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Jobs/AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Threading.Tasks;
+using Arcus.BackgroundJobs.Tests.Integration.Fixture.KeyVault;
+using Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus;
+using Arcus.BackgroundJobs.Tests.Integration.Hosting;
+using Arcus.BackgroundJobs.Tests.Integration.Hosting.ServiceBus;
+using Arcus.EventGrid.Publishing;
+using Arcus.Security.Providers.AzureKeyVault.Authentication;
+using Arcus.Testing.Logging;
+using Microsoft.Azure.KeyVault;
+using Microsoft.Azure.Management.ServiceBus.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Jobs
+{
+    [Trait("Category", "Integration")]
+    public class AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests
+    {
+        private readonly ILogger _logger;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests" /> class.
+        /// </summary>
+        public AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests(ITestOutputHelper outputWriter)
+        {
+            _logger = new XunitTestLogger(outputWriter);
+        }
+        
+        [Fact]
+        public async Task ServiceBusMessagePump_RotateServiceBusConnectionKeysOnSecretNewVersionNotification_MessagePumpRestartsThenMessageSuccessfullyProcessed()
+        {
+            // Arrange
+            var config = TestConfig.Create();
+            KeyRotationConfig rotationConfig = config.GetKeyRotationConfig();
+            _logger.LogInformation("Using Service Principal [ClientID: '{0}']", rotationConfig.ServicePrincipal.ClientId);
+
+            var client = new ServiceBusConfiguration(rotationConfig, _logger);
+            string freshConnectionString = await client.RotateConnectionStringKeysForQueueAsync(KeyType.PrimaryKey);
+
+            IKeyVaultClient keyVaultClient = await CreateKeyVaultClientAsync(rotationConfig);
+            await SetConnectionStringInKeyVaultAsync(keyVaultClient, rotationConfig, freshConnectionString);
+
+            string jobId = Guid.NewGuid().ToString();
+            const string connectionStringSecretKey = "ARCUS_KEYVAULT_SECRETNEWVERSIONCREATED_CONNECTIONSTRING";
+
+            var options = new WorkerOptions();
+            options.Configuration.Add(connectionStringSecretKey, rotationConfig.KeyVault.SecretNewVersionCreated.ConnectionString);
+            AddEventGridPublisher(options, config);
+            AddSecretStore(options, rotationConfig);
+            AddServiceBusMessagePump(options, rotationConfig, jobId);
+            
+            options.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                jobId: jobId,
+                subscriptionNamePrefix: "TestSub",
+                serviceBusTopicConnectionStringSecretKey: connectionStringSecretKey,
+                messagePumpConnectionStringKey: rotationConfig.KeyVault.SecretName);
+
+            await using (var worker = await Worker.StartNewAsync(options))
+            {
+                string newSecondaryConnectionString = await client.RotateConnectionStringKeysForQueueAsync(KeyType.SecondaryKey);
+                await SetConnectionStringInKeyVaultAsync(keyVaultClient, rotationConfig, newSecondaryConnectionString);
+
+                await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
+                {
+                    // Act
+                    string newPrimaryConnectionString = await client.RotateConnectionStringKeysForQueueAsync(KeyType.PrimaryKey);
+
+                    // Assert
+                    await service.SimulateMessageProcessingAsync(newPrimaryConnectionString);
+                }
+            }
+        }
+
+        private static async Task<IKeyVaultClient> CreateKeyVaultClientAsync(KeyRotationConfig rotationConfig)
+        {
+            ServicePrincipalAuthentication authentication = rotationConfig.ServicePrincipal.CreateAuthentication();
+            IKeyVaultClient keyVaultClient = await authentication.AuthenticateAsync();
+            
+            return keyVaultClient;
+        }
+
+        private static async Task SetConnectionStringInKeyVaultAsync(IKeyVaultClient keyVaultClient, KeyRotationConfig keyRotationConfig, string rotatedConnectionString)
+        {
+            await keyVaultClient.SetSecretAsync(
+                vaultBaseUrl: keyRotationConfig.KeyVault.VaultUri,
+                secretName: keyRotationConfig.KeyVault.SecretName,
+                value: rotatedConnectionString);
+        }
+
+        private static void AddEventGridPublisher(WorkerOptions options, TestConfig config)
+        {
+            options.Services.AddTransient(svc =>
+            {
+                string eventGridTopic = config.GetTestInfraEventGridTopicUri();
+                string eventGridKey = config.GetTestInfraEventGridAuthKey();
+                return EventGridPublisherBuilder
+                       .ForTopic(eventGridTopic)
+                       .UsingAuthenticationKey(eventGridKey)
+                       .Build();
+            });
+        }
+
+        private static void AddSecretStore(WorkerOptions options, KeyRotationConfig rotationConfig)
+        {
+            options.Configure(host => host.ConfigureSecretStore((configuration, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(
+                          rotationConfig.KeyVault.VaultUri,
+                          rotationConfig.ServicePrincipal.ClientId,
+                          rotationConfig.ServicePrincipal.ClientSecret)
+                      .AddConfiguration(configuration);
+            }));
+        }
+
+        private static void AddServiceBusMessagePump(WorkerOptions options, KeyRotationConfig rotationConfig, string jobId)
+        {
+            options.AddServiceBusQueueMessagePump(rotationConfig.KeyVault.SecretName, opt =>
+            {
+                opt.JobId = jobId;
+                // Unrealistic big maximum exception count so that we're certain that the message pump gets restarted based on the notification and not the unauthorized exception.
+                opt.MaximumUnauthorizedExceptionsBeforeRestart = 1000;
+            }).WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/appsettings.json
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/appsettings.json
@@ -1,5 +1,15 @@
 ﻿{
   "Arcus": {
+    "Infra": {
+      "EventGrid": {
+        "TopicUri": "#{Arcus.TestInfra.EventGrid.Topic.Uri}#",
+        "AuthKey": "#{Arcus.TestInfra.EventGrid.Auth.Key}#"
+      },
+      "ServiceBus": {
+        "TopicName": "#{Arcus.TestInfra.ServiceBus.Topic.Name}#",
+        "ConnectionString": "#{Arcus.TestInfra.ServiceBus.Topic.ConnectionString}#"
+      }
+    },
     "KeyVault": {
       "Uri": "#{Arcus.KeyVault.Uri}#"
     },
@@ -11,9 +21,32 @@
       "ConnectionStringWithTopic": "#{ServiceBus.Topics.KeyVaultEvents.ConnectionString}#"
     },
     "Databricks": {
-      "Url":  "#{Arcus.Databricks.Url}#",
+      "Url": "#{Arcus.Databricks.Url}#",
       "Token": "#{Arcus.Databricks.Token}#",
-      "JobId": "#{Arcus.Databricks.JobId}#" 
-    } 
+      "JobId": "#{Arcus.Databricks.JobId}#"
+    },
+    "KeyRotation": {
+      "ServicePrincipal": {
+        "ClientId": "#{Arcus.KeyRotation.ServicePrincipal.ClientId}#",
+        "ClientSecret": "#{Arcus.KeyRotation.ServicePrincipal.ClientSecret}#",
+        "ClientSecretKey": "#{Arcus.KeyRotation.ServicePrincipal.ClientSecretKey}#"
+      },
+      "ServiceBus": {
+        "ResourceGroupName": "#{Arcus.KeyRotation.ServiceBus.ResourceGroupName}#",
+        "TenantId": "#{Arcus.KeyRotation.ServiceBus.TenantId}#",
+        "SubscriptionId": "#{Arcus.KeyRotation.ServiceBus.SubscriptionId}#",
+        "Namespace": "#{Arcus.KeyRotation.ServiceBus.Namespace}#",
+        "QueueName": "#{Arcus.KeyRotation.ServiceBus.QueueName}#",
+        "TopicName": "#{Arcus.KeyRotation.ServiceBus.TopicName}#",
+        "AuthorizationRuleName": "#{Arcus.KeyRotation.ServiceBus.AuthorizationRuleName}#"
+      },
+      "KeyVault": {
+        "VaultUri": "#{Arcus.KeyRotation.KeyVault.VaultUri}#",
+        "ConnectionStringSecretName": "#{Arcus.KeyRotation.KeyVault.ConnectionStringSecretName}#",
+        "SecretNewVersionCreated": {
+          "ServiceBusConnectionStringWithTopicEndpoint": "#{Arcus.KeyRotation.KeyVault.SecretNewVersionCreated.ServiceBusConnectionStringWithTopicEndpoint}#"
+        }
+      }
+    }
   }
 }

--- a/src/Arcus.BackgroundJobs.Tests.Unit/Arcus.BackgroundJobs.Tests.Unit.csproj
+++ b/src/Arcus.BackgroundJobs.Tests.Unit/Arcus.BackgroundJobs.Tests.Unit.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Arcus.BackgroundJobs.Databricks\Arcus.BackgroundJobs.Databricks.csproj" />
+    <ProjectReference Include="..\Arcus.BackgroundJobs.KeyVault\Arcus.BackgroundJobs.KeyVault.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.BackgroundJobs.Tests.Unit/Blanks.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Unit/Blanks.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Arcus.BackgroundJobs.Tests.Unit
+{
+    /// <summary>
+    /// Represents a sequence of blank inputs used for data-driven tests.
+    /// </summary>
+    public class Blanks : IEnumerable<object[]>
+    {
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] {null};
+            yield return new object[] {""};
+            yield return new object[] {" "};
+            yield return new object[] {"     "};
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Unit/KeyVault/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Unit/KeyVault/IServiceCollectionExtensionsTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Arcus.Messaging.Pumps.ServiceBus;
+using CloudNative.CloudEvents;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Arcus.BackgroundJobs.Tests.Unit.KeyVault
+{
+    [Trait("Category", "Unit")]
+    // ReSharper disable once InconsistentNaming
+    public class IServiceCollectionExtensionsTests
+    {
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestart_WithoutJobId_Fails(string jobId)
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => collection.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                    jobId,
+                    "subscription-prefix",
+                    "service bus topic connection string secret key",
+                    "message pump connection string key"));
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void WithAutoRestart_WithoutSubscriptionPrefix_Fails(string subscriptionPrefix)
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => collection.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                    "job ID",
+                    subscriptionPrefix,
+                    "service bus topic connection string secret key",
+                    "message pump connection string key"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void WithAutoRestart_WithoutSubscriptionTopicConnectionStringSecretKey_Fails(
+            string serviceBusTopicConnectionStringSecretKey)
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => collection.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                    "job ID",
+                    "subscription-prefix",
+                    serviceBusTopicConnectionStringSecretKey,
+                    "message pump connection string key"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void WithAutoRestart_WithoutMessagePumpConnectionStringKey_Fails(string messagePumpConnectionStringKey)
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => collection.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                    "job ID",
+                    "subscription-prefix",
+                    "service bus topic connection string secret key",
+                    messagePumpConnectionStringKey));
+        }
+
+        [Fact]
+        public void WithAutoRestart_WithoutRelatedMessagePump_Fails()
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+            collection.AddSingleton<IConfiguration>(new ConfigurationRoot(new List<IConfigurationProvider>()));
+            collection.AddLogging();
+            
+            // Act
+            collection.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                "job ID",
+                "subscription-prefix",
+                "service bus topic connection string secret key",
+                "message pump connection string key");
+            
+            // Assert
+            IServiceProvider provider = collection.BuildServiceProvider();
+            var exception = Assert.ThrowsAny<InvalidOperationException>(() =>
+                provider.GetRequiredService<IMessageHandler<CloudEvent, AzureServiceBusMessageContext>>());
+            Assert.Contains("Cannot register re-authentication", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
Moves the Azure Service Bus auto-restart on rotated credentials functionality from the messaging repo to here, as it's a background job.

Closes #69 