### PR TITLE
feat: configurable messaging options in cloudevents background job

### DIFF
--- a/src/Arcus.BackgroundJobs.CloudEvents/Arcus.BackgroundJobs.CloudEvents.csproj
+++ b/src/Arcus.BackgroundJobs.CloudEvents/Arcus.BackgroundJobs.CloudEvents.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="[1.0.0,2.0.0)" />
+    <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="[1.0.1,2.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 

--- a/src/Arcus.BackgroundJobs.CloudEvents/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.BackgroundJobs.CloudEvents/Extensions/IServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Arcus.BackgroundJobs.CloudEvents;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Arcus.Messaging.Pumps.ServiceBus.Configuration;
 using CloudNative.CloudEvents;
 using GuardNet;
 using Microsoft.Extensions.Logging;
@@ -36,13 +37,43 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNullOrWhitespace(subscriptionNamePrefix, nameof(subscriptionNamePrefix), "Requires a non-blank subscription name of the Azure Service Bus Topic subscription");
             Guard.NotNullOrWhitespace(serviceBusNamespaceConnectionStringSecretKey, nameof(serviceBusNamespaceConnectionStringSecretKey), "Requires a non-blank secret key that points to a Azure Service Bus namespace-scoped connection string");
 
+            return AddCloudEventBackgroundJob(services, topicName, subscriptionNamePrefix, serviceBusNamespaceConnectionStringSecretKey, configureBackgroundJob: null);
+        }
+        
+        /// <summary>
+        /// Adds a background job to the <see cref="IServiceCollection"/> to receive <see cref="CloudEvent"/>'s.
+        /// </summary>
+        /// <param name="services">The services collection to add the job to.</param>
+        /// <param name="topicName"></param>
+        /// <param name="subscriptionNamePrefix">The name of the Azure Service Bus subscription that will be created to receive <see cref="CloudEvent"/>'s.</param>
+        /// <param name="serviceBusNamespaceConnectionStringSecretKey">The secret key that points to the Azure Service Bus namespace-scoped connection string.</param>
+        /// <param name="configureBackgroundJob">The capability to configure additional options on how the CloudEvents background job should behave.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="topicName"/>, the <paramref name="subscriptionNamePrefix"/>, or the <paramref name="serviceBusNamespaceConnectionStringSecretKey"/> is blank.
+        /// </exception>
+        public static ServiceBusMessageHandlerCollection AddCloudEventBackgroundJob(
+            this IServiceCollection services,
+            string topicName,
+            string subscriptionNamePrefix,
+            string serviceBusNamespaceConnectionStringSecretKey,
+            Action<IAzureServiceBusTopicMessagePumpOptions> configureBackgroundJob)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a set of services to add the CloudEvents background job to");
+            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus Topic name to identity the Azure Service Bus entity");
+            Guard.NotNullOrWhitespace(subscriptionNamePrefix, nameof(subscriptionNamePrefix), "Requires a non-blank subscription name of the Azure Service Bus Topic subscription");
+            Guard.NotNullOrWhitespace(serviceBusNamespaceConnectionStringSecretKey, nameof(serviceBusNamespaceConnectionStringSecretKey), "Requires a non-blank secret key that points to a Azure Service Bus namespace-scoped connection string");
+
             services.AddServiceBusMessageRouting(serviceProvider =>
             {
+                var options = new AzureServiceBusMessagePumpOptions();
+                configureBackgroundJob?.Invoke(options);
+
                 var logger = serviceProvider.GetRequiredService<ILogger<CloudEventMessageRouter>>();
-                return new CloudEventMessageRouter(serviceProvider, new AzureServiceBusMessageRouterOptions(), logger);
+                return new CloudEventMessageRouter(serviceProvider, options.Routing, logger);
             });
 
-            return services.AddServiceBusTopicMessagePumpWithPrefix(topicName, subscriptionNamePrefix, serviceBusNamespaceConnectionStringSecretKey);
+            return services.AddServiceBusTopicMessagePumpWithPrefix(topicName, subscriptionNamePrefix, serviceBusNamespaceConnectionStringSecretKey, configureBackgroundJob);
         }
 
         /// <summary>
@@ -64,13 +95,40 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNullOrWhitespace(subscriptionNamePrefix, nameof(subscriptionNamePrefix), "Requires a non-blank subscription name of the Azure Service Bus Topic subscription, to receive Key Vault events");
             Guard.NotNullOrWhitespace(serviceBusTopicConnectionStringSecretKey, nameof(serviceBusTopicConnectionStringSecretKey), "Requires a non-blank secret key that points to a Azure Service Bus Topic-scoped connection string");
 
+            return AddCloudEventBackgroundJob(services, subscriptionNamePrefix, serviceBusTopicConnectionStringSecretKey, configureBackgroundJob: null);
+        }
+
+        /// <summary>
+        /// Adds a background job to the <see cref="IServiceCollection"/> to receive <see cref="CloudEvent"/>'s.
+        /// </summary>
+        /// <param name="services">The services collection to add the job to.</param>
+        /// <param name="subscriptionNamePrefix">The name of the Azure Service Bus subscription that will be created to receive <see cref="CloudEvent"/>'s.</param>
+        /// <param name="serviceBusTopicConnectionStringSecretKey">The secret key that points to the Azure Service Bus Topic-scoped connection string.</param>
+        /// <param name="configureBackgroundJob">The capability to configure additional options on how the CloudEvents background job should behave.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="subscriptionNamePrefix"/>, or the <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.
+        /// </exception>
+        public static ServiceBusMessageHandlerCollection AddCloudEventBackgroundJob(
+            this IServiceCollection services,
+            string subscriptionNamePrefix,
+            string serviceBusTopicConnectionStringSecretKey,
+            Action<IAzureServiceBusTopicMessagePumpOptions> configureBackgroundJob)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a set of services to add the CloudEvents background job to");
+            Guard.NotNullOrWhitespace(subscriptionNamePrefix, nameof(subscriptionNamePrefix), "Requires a non-blank subscription name of the Azure Service Bus Topic subscription, to receive Key Vault events");
+            Guard.NotNullOrWhitespace(serviceBusTopicConnectionStringSecretKey, nameof(serviceBusTopicConnectionStringSecretKey), "Requires a non-blank secret key that points to a Azure Service Bus Topic-scoped connection string");
+
             services.AddServiceBusMessageRouting(serviceProvider =>
             {
+                var options = new AzureServiceBusMessagePumpOptions();
+                configureBackgroundJob?.Invoke(options);
+                
                 var logger = serviceProvider.GetRequiredService<ILogger<CloudEventMessageRouter>>();
-                return new CloudEventMessageRouter(serviceProvider, new AzureServiceBusMessageRouterOptions(), logger);
+                return new CloudEventMessageRouter(serviceProvider, options.Routing, logger);
             });
 
-            return services.AddServiceBusTopicMessagePumpWithPrefix(subscriptionNamePrefix, serviceBusTopicConnectionStringSecretKey);
+            return services.AddServiceBusTopicMessagePumpWithPrefix(subscriptionNamePrefix, serviceBusTopicConnectionStringSecretKey, configureBackgroundJob);
         }
     }
 }

--- a/src/Arcus.BackgroundJobs.KeyVault/Arcus.BackgroundJobs.KeyVault.csproj
+++ b/src/Arcus.BackgroundJobs.KeyVault/Arcus.BackgroundJobs.KeyVault.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="[1.0.0,2.0.0)" />
+    <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="[1.0.1,2.0.0)" />
     <PackageReference Include="Arcus.Security.Core" Version="[1.4.0,2.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>

--- a/src/Arcus.BackgroundJobs.Tests.Integration/CloudEvents/CloudEventBackgroundJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/CloudEvents/CloudEventBackgroundJobTests.cs
@@ -3,15 +3,22 @@ using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
 using Arcus.BackgroundJobs.Tests.Integration.CloudEvents.Fixture;
+using Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus;
 using Arcus.BackgroundJobs.Tests.Integration.Hosting;
 using Arcus.EventGrid;
 using Arcus.EventGrid.Contracts;
 using Arcus.EventGrid.Publishing;
 using Arcus.EventGrid.Publishing.Interfaces;
+using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Pumps.ServiceBus;
 using Arcus.Testing.Logging;
+using Azure;
 using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using Bogus;
 using CloudNative.CloudEvents;
 using Microsoft.Azure.EventGrid.Models;
+using Microsoft.Azure.ServiceBus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -24,13 +31,20 @@ namespace Arcus.BackgroundJobs.Tests.Integration.CloudEvents
    [Trait("Category", "Integration")]
     public class CloudEventBackgroundJobTests
     {
+        private const string TopicConnectionStringSecretKey = "Arcus:ServiceBus:ConnectionStringWithTopic",
+                             NamespaceConnectionStringSecretKey = "Arcus:ServiceBus:NamespaceConnectionString";
+
+        private readonly TestConfig _configuration;
         private readonly ILogger _logger;
 
+        private static readonly Faker BogusGenerator = new Faker();
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudEventBackgroundJobTests" /> class.
         /// </summary>
         public CloudEventBackgroundJobTests(ITestOutputHelper outputWriter)
         {
+            _configuration = TestConfig.Create();
             _logger = new XunitTestLogger(outputWriter);
         }
 
@@ -38,25 +52,22 @@ namespace Arcus.BackgroundJobs.Tests.Integration.CloudEvents
         public async Task CloudEventsBackgroundJobOnNamespace_ReceivesCloudEvents_ProcessesCorrectly()
         {
             // Arrange
-            var configuration = TestConfig.Create();
-            var topicConnectionStringSecretKey = "Arcus:ServiceBus:ConnectionStringWithTopic";
-            var namespaceConnectionStringSecretKey = "Arcus:ServiceBus:NamespaceConnectionString";
-            var topicConnectionString = configuration.GetValue<string>(topicConnectionStringSecretKey);
-            var connectionStringBuilder = ServiceBusConnectionStringProperties.Parse(topicConnectionString);
-            IEventGridPublisher eventGridPublisher = CreateEventGridPublisher(configuration);
+            var topicConnectionString = _configuration.GetValue<string>(TopicConnectionStringSecretKey);
+            var properties = ServiceBusConnectionStringProperties.Parse(topicConnectionString);
+            IEventGridPublisher eventGridPublisher = CreateEventGridPublisher(_configuration);
             
             var options = new WorkerOptions();
             options.Configure(host =>
             {
-                host.ConfigureAppConfiguration(context => context.AddConfiguration(configuration))
+                host.ConfigureAppConfiguration(context => context.AddConfiguration(_configuration))
                     .ConfigureSecretStore((config, stores) => stores.AddConfiguration(config)); 
             });
             options.ConfigureLogging(_logger)
                    .AddSingleton(eventGridPublisher)
                    .AddCloudEventBackgroundJob(
-                       topicName: connectionStringBuilder.EntityPath,
+                       topicName: properties.EntityPath,
                        subscriptionNamePrefix: "Test-", 
-                       serviceBusNamespaceConnectionStringSecretKey: namespaceConnectionStringSecretKey)
+                       serviceBusNamespaceConnectionStringSecretKey: NamespaceConnectionStringSecretKey)
                    .WithServiceBusMessageHandler<CloudEventToEventGridAzureServiceBusMessageHandler, CloudEvent>();
 
             CloudEvent expected = CreateCloudEvent();
@@ -64,8 +75,134 @@ namespace Arcus.BackgroundJobs.Tests.Integration.CloudEvents
 
             await using (var worker = await Worker.StartNewAsync(options))
             {
-                var producer = TestServiceBusEventProducer.Create(topicConnectionStringSecretKey, configuration);
-                await using (var consumer = await TestServiceBusEventConsumer.StartNewAsync(configuration, _logger))
+                var producer = TestServiceBusEventProducer.Create(TopicConnectionStringSecretKey, _configuration);
+                await using (var consumer = await TestServiceBusEventConsumer.StartNewAsync(_configuration, _logger))
+                {
+                    // Act
+                    await producer.ProduceAsync(message);
+                    
+                    // Assert
+                    EventBatch<Event> eventBatch = consumer.Consume(expected.Id);
+                    Event @event = Assert.Single(eventBatch.Events);
+                    CloudEvent actual = @event.AsCloudEvent();
+                    Assert.Equal(expected.Id, actual.Id);
+
+                    var expectedData = expected.GetPayload<StorageBlobCreatedEventData>();
+                    var actualData = actual.GetPayload<StorageBlobCreatedEventData>();
+                    Assert.Equal(expectedData.Api, actualData.Api);
+                    Assert.Equal(expectedData.ClientRequestId, actualData.ClientRequestId);
+                }
+            }
+        }
+        
+        [Fact]
+        public async Task CloudEventsBackgroundJobOnNamespaceWithIgnoringMissingMembersDeserialization_ReceivesCloudEvents_MessageGetsProcessedByDifferentMessageHandler()
+        {
+            // Arrange
+            var topicConnectionString = _configuration.GetValue<string>(TopicConnectionStringSecretKey);
+            var properties = ServiceBusConnectionStringProperties.Parse(topicConnectionString);
+            IEventGridPublisher eventGridPublisher = CreateEventGridPublisher(_configuration);
+            
+            var options = new WorkerOptions();
+            options.Configure(host =>
+            {
+                host.ConfigureAppConfiguration(context => context.AddConfiguration(_configuration))
+                    .ConfigureSecretStore((config, stores) => stores.AddConfiguration(config)); 
+            });
+            options.ConfigureLogging(_logger)
+                   .AddSingleton(eventGridPublisher)
+                   .AddCloudEventBackgroundJob(
+                       topicName: properties.EntityPath,
+                       subscriptionNamePrefix: "Test-", 
+                       serviceBusNamespaceConnectionStringSecretKey: NamespaceConnectionStringSecretKey,
+                       opt => opt.Deserialization.AdditionalMembers = AdditionalMemberHandling.Ignore)
+                   .WithServiceBusMessageHandler<OrdersV2AzureServiceBusMessageHandler, OrderV2>();
+
+            var operationId = $"operation-{Guid.NewGuid()}";
+            OrderV2 order = OrderGenerator.GenerateOrderV2();
+            ServiceBusMessage message = order.AsServiceBusMessage(operationId: operationId);
+
+            await using (var worker = await Worker.StartNewAsync(options))
+            {
+                var producer = TestServiceBusEventProducer.Create(TopicConnectionStringSecretKey, _configuration);
+                await using (var consumer = await TestServiceBusEventConsumer.StartNewAsync(_configuration, _logger))
+                {
+                    // Act
+                    await producer.ProduceAsync(message);
+                    
+                    // Assert
+                    EventBatch<Event> eventBatch = consumer.Consume(operationId);
+                    Event @event = Assert.Single(eventBatch.Events);
+
+                    var orderCreatedEventData = @event.GetPayload<OrderCreatedEventData>();
+                    Assert.NotNull(orderCreatedEventData);
+                    Assert.NotNull(orderCreatedEventData.CorrelationInfo);
+                    Assert.Equal(order.Id, orderCreatedEventData.Id);
+                    Assert.Equal(order.Amount, orderCreatedEventData.Amount);
+                    Assert.Equal(order.ArticleNumber, orderCreatedEventData.ArticleNumber);
+                    Assert.NotEmpty(orderCreatedEventData.CorrelationInfo.CycleId);
+                }
+            }
+        }
+        
+        [Fact]
+        public async Task CloudEventsBackgroundJobOnNamespace_WithNoneTopicSubscription_DoesntCreateTopicSubscription()
+        {
+            // Arrange
+            string topicConnectionString = _configuration.GetValue<string>(TopicConnectionStringSecretKey);
+            var properties = ServiceBusConnectionStringProperties.Parse(topicConnectionString);
+            IEventGridPublisher eventGridPublisher = CreateEventGridPublisher(_configuration);
+            
+            var options = new WorkerOptions();
+            string subscriptionPrefix = BogusGenerator.Name.Prefix();
+            options.AddSingleton(eventGridPublisher)
+                   .AddCloudEventBackgroundJob(
+                       topicName: properties.EntityPath,
+                       subscriptionNamePrefix: subscriptionPrefix, 
+                       serviceBusNamespaceConnectionStringSecretKey: NamespaceConnectionStringSecretKey,
+                       opt => opt.TopicSubscription = TopicSubscription.None)
+                   .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
+            
+            // Act
+            await using (var worker = await Worker.StartNewAsync(options))
+            {
+                var client = new ServiceBusAdministrationClient(topicConnectionString);
+
+                SubscriptionProperties subscription = await GetTopicSubscriptionFromPrefix(client, subscriptionPrefix, properties.EntityPath);
+                if (subscription != null)
+                {
+                    await client.DeleteSubscriptionAsync(properties.EntityPath, subscription.SubscriptionName); 
+                }
+                
+                Assert.Null(subscription);
+            }
+        }
+
+        [Fact]
+        public async Task CloudEventsBackgroundJobOnTopic_ReceivesCloudEvents_ProcessesCorrectly()
+        {
+            // Arrange
+            IEventGridPublisher eventGridPublisher = CreateEventGridPublisher(_configuration);
+            
+            var options = new WorkerOptions();
+            options.Configure(host =>
+                   {
+                       host.ConfigureAppConfiguration(context => context.AddConfiguration(_configuration))
+                           .ConfigureSecretStore((config, stores) => stores.AddConfiguration(config));
+                   }).ConfigureLogging(_logger)
+                   .AddSingleton(eventGridPublisher)
+                   .AddCloudEventBackgroundJob(
+                       subscriptionNamePrefix: "Test-",
+                       serviceBusTopicConnectionStringSecretKey: TopicConnectionStringSecretKey)
+                   .WithServiceBusMessageHandler<CloudEventToEventGridAzureServiceBusMessageHandler, CloudEvent>();
+
+            CloudEvent expected = CreateCloudEvent();
+            ServiceBusMessage message = CreateServiceBusMessageFor(expected);
+
+            await using (var worker = await Worker.StartNewAsync(options))
+            {
+                var producer = TestServiceBusEventProducer.Create(TopicConnectionStringSecretKey, _configuration);
+                await using (var consumer = await TestServiceBusEventConsumer.StartNewAsync(_configuration, _logger))
                 {
                     // Act
                     await producer.ProduceAsync(message);
@@ -85,47 +222,81 @@ namespace Arcus.BackgroundJobs.Tests.Integration.CloudEvents
         }
 
         [Fact]
-        public async Task CloudEventsBackgroundJobOnTopic_ReceivesCloudEvents_ProcessesCorrectly()
+        public async Task CloudEventsBackgroundJobWithIgnoringMissingMembersDeserialization_ReceivesCloudEvents_MessageGetsProcessedByDifferentMessageHandler()
         {
             // Arrange
-            var configuration = TestConfig.Create();
-            const string topicConnectionStringSecretKey = "Arcus:ServiceBus:ConnectionStringWithTopic";
-            IEventGridPublisher eventGridPublisher = CreateEventGridPublisher(configuration);
+            IEventGridPublisher eventGridPublisher = CreateEventGridPublisher(_configuration);
             
             var options = new WorkerOptions();
             options.Configure(host =>
                    {
-                       host.ConfigureAppConfiguration(context => context.AddConfiguration(configuration))
+                       host.ConfigureAppConfiguration(context => context.AddConfiguration(_configuration))
                            .ConfigureSecretStore((config, stores) => stores.AddConfiguration(config));
                    }).ConfigureLogging(_logger)
                    .AddSingleton(eventGridPublisher)
                    .AddCloudEventBackgroundJob(
                        subscriptionNamePrefix: "Test-",
-                       serviceBusTopicConnectionStringSecretKey: topicConnectionStringSecretKey)
-                   .WithServiceBusMessageHandler<CloudEventToEventGridAzureServiceBusMessageHandler, CloudEvent>();
+                       serviceBusTopicConnectionStringSecretKey: TopicConnectionStringSecretKey,
+                       opt => opt.Deserialization.AdditionalMembers = AdditionalMemberHandling.Ignore)
+                   .WithServiceBusMessageHandler<OrdersV2AzureServiceBusMessageHandler, OrderV2>();
 
-            CloudEvent expected = CreateCloudEvent();
-            ServiceBusMessage message = CreateServiceBusMessageFor(expected);
-
+            var operationId = $"operation-{Guid.NewGuid()}";
+            OrderV2 order = OrderGenerator.GenerateOrderV2();
+            ServiceBusMessage message = order.AsServiceBusMessage(operationId: operationId);
+            
+            // Act
             await using (var worker = await Worker.StartNewAsync(options))
             {
-                var producer = TestServiceBusEventProducer.Create(topicConnectionStringSecretKey, configuration);
-                await using (var consumer = await TestServiceBusEventConsumer.StartNewAsync(configuration, _logger))
+                var producer = TestServiceBusEventProducer.Create(TopicConnectionStringSecretKey, _configuration);
+                await using (var consumer = await TestServiceBusEventConsumer.StartNewAsync(_configuration, _logger))
                 {
                     // Act
                     await producer.ProduceAsync(message);
                     
                     // Assert
-                    EventBatch<Event> eventBatch = consumer.Consume(expected.Id);
+                    EventBatch<Event> eventBatch = consumer.Consume(operationId);
                     Event @event = Assert.Single(eventBatch.Events);
-                    CloudEvent actual = @event.AsCloudEvent();
-                    Assert.Equal(expected.Id, actual.Id);
 
-                    var expectedData = expected.GetPayload<StorageBlobCreatedEventData>();
-                    var actualData = actual.GetPayload<StorageBlobCreatedEventData>();
-                    Assert.Equal(expectedData.Api, actualData.Api);
-                    Assert.Equal(expectedData.ClientRequestId, actualData.ClientRequestId);
+                    var orderCreatedEventData = @event.GetPayload<OrderCreatedEventData>();
+                    Assert.NotNull(orderCreatedEventData);
+                    Assert.NotNull(orderCreatedEventData.CorrelationInfo);
+                    Assert.Equal(order.Id, orderCreatedEventData.Id);
+                    Assert.Equal(order.Amount, orderCreatedEventData.Amount);
+                    Assert.Equal(order.ArticleNumber, orderCreatedEventData.ArticleNumber);
+                    Assert.NotEmpty(orderCreatedEventData.CorrelationInfo.CycleId);
                 }
+            }
+        }
+        
+        [Fact]
+        public async Task CloudEventsBackgroundJobOnTopic_WithNoneTopicSubscription_DoesntCreateTopicSubscription()
+        {
+            // Arrange
+            string topicConnectionString = _configuration.GetValue<string>(TopicConnectionStringSecretKey);
+            var properties = ServiceBusConnectionStringProperties.Parse(topicConnectionString);
+            IEventGridPublisher eventGridPublisher = CreateEventGridPublisher(_configuration);
+            
+            var options = new WorkerOptions();
+            string subscriptionPrefix = BogusGenerator.Name.Prefix();
+            options.AddSingleton(eventGridPublisher)
+                   .AddCloudEventBackgroundJob(
+                       subscriptionNamePrefix: subscriptionPrefix,
+                       serviceBusTopicConnectionStringSecretKey: TopicConnectionStringSecretKey,
+                       opt => opt.TopicSubscription = TopicSubscription.None)
+                   .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
+            
+            // Act
+            await using (var worker = await Worker.StartNewAsync(options))
+            {
+                var client = new ServiceBusAdministrationClient(topicConnectionString);
+
+                SubscriptionProperties subscription = await GetTopicSubscriptionFromPrefix(client, subscriptionPrefix, properties.EntityPath);
+                if (subscription != null)
+                {
+                    await client.DeleteSubscriptionAsync(properties.EntityPath, subscription.SubscriptionName); 
+                }
+                
+                Assert.Null(subscription);
             }
         }
 
@@ -173,6 +344,7 @@ namespace Arcus.BackgroundJobs.Tests.Integration.CloudEvents
         {
             var formatter = new JsonEventFormatter();
             byte[] bytes = formatter.EncodeStructuredEvent(cloudEvent, out ContentType contentType);
+
             var message = new ServiceBusMessage(bytes)
             {
                 ApplicationProperties =
@@ -181,8 +353,23 @@ namespace Arcus.BackgroundJobs.Tests.Integration.CloudEvents
                     {"Message-Encoding", Encoding.UTF8.WebName}
                 }
             };
-            
+
             return message;
+        }
+
+        private static async Task<SubscriptionProperties> GetTopicSubscriptionFromPrefix(ServiceBusAdministrationClient client, string subscriptionPrefix, string topicName)
+        {
+            AsyncPageable<SubscriptionProperties> subscriptionsResult = client.GetSubscriptionsAsync(topicName);
+                
+            await foreach (SubscriptionProperties subscriptionProperties in subscriptionsResult)
+            {
+                if (subscriptionProperties.SubscriptionName.StartsWith(subscriptionPrefix))
+                {
+                    return subscriptionProperties;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/OrderGenerator.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/OrderGenerator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Bogus;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus
+{
+    public static class OrderGenerator
+    {
+        public static Order GenerateOrder()
+        {
+            var customerGenerator = new Faker<Customer>()
+                .RuleFor(u => u.FirstName, (f, u) => f.Name.FirstName())
+                .RuleFor(u => u.LastName, (f, u) => f.Name.LastName());
+
+            var orderGenerator = new Faker<Order>()
+                .RuleFor(u => u.Customer, () => customerGenerator)
+                .RuleFor(u => u.Id, f => Guid.NewGuid().ToString())
+                .RuleFor(u => u.Amount, f => f.Random.Int())
+                .RuleFor(u => u.ArticleNumber, f => f.Commerce.Product());
+
+            return orderGenerator.Generate();
+        }
+        
+        public static OrderV2 GenerateOrderV2()
+        {
+            var customerGenerator = new Faker<Customer>()
+                .RuleFor(u => u.FirstName, (f, u) => f.Name.FirstName())
+                .RuleFor(u => u.LastName, (f, u) => f.Name.LastName());
+
+            var orderGenerator = new Faker<OrderV2>()
+                .RuleFor(u => u.Customer, () => customerGenerator)
+                .RuleFor(u => u.Id, f => Guid.NewGuid().ToString())
+                .RuleFor(u => u.Amount, f => f.Random.Int())
+                .RuleFor(u => u.ArticleNumber, f => f.Commerce.Product())
+                .RuleFor(u => u.Status, f => f.Random.Int(min: 0));
+
+            return orderGenerator.Generate();
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/OrderV2.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/OrderV2.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus
+{
+    public class OrderV2
+    {
+        [JsonProperty]
+        public string Id { get; set; }
+
+        [JsonProperty]
+        public int Amount { get; set; }
+
+        [JsonProperty]
+        public string ArticleNumber { get; set; }
+
+        [JsonProperty]
+        public Customer Customer { get; set; }
+        
+        [JsonProperty]
+        public int Status { get; set; }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/OrdersV2AzureServiceBusMessageHandler.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Fixture/ServiceBus/OrdersV2AzureServiceBusMessageHandler.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Net.Mime;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.EventGrid.Publishing.Interfaces;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using CloudNative.CloudEvents;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.Fixture.ServiceBus
+{
+    public class OrdersV2AzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<OrderV2>
+    {
+        private readonly IEventGridPublisher _eventGridPublisher;
+        private readonly ILogger _logger;
+
+        public OrdersV2AzureServiceBusMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrdersV2AzureServiceBusMessageHandler> logger)
+        {
+            Guard.NotNull(eventGridPublisher, nameof(eventGridPublisher));
+            Guard.NotNull(logger, nameof(logger));
+
+            _eventGridPublisher = eventGridPublisher;
+            _logger = logger;
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="order">Message that was received</param>
+        /// <param name="azureMessageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public async Task ProcessMessageAsync(
+            OrderV2 order,
+            AzureServiceBusMessageContext azureMessageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", 
+                                   order.Id, order.Amount, order.ArticleNumber, order.Customer.FirstName, order.Customer.LastName);
+
+            await PublishEventToEventGridAsync(order, correlationInfo.OperationId, correlationInfo);
+
+            _logger.LogInformation("Order {OrderId} processed", order.Id);
+        }
+
+        private async Task PublishEventToEventGridAsync(OrderV2 orderMessage, string operationId, MessageCorrelationInfo correlationInfo)
+        {
+            var eventData = new OrderCreatedEventData(
+                orderMessage.Id,
+                orderMessage.Amount,
+                orderMessage.ArticleNumber,
+                $"{orderMessage.Customer.FirstName} {orderMessage.Customer.LastName}",
+                correlationInfo);
+
+            var orderCreatedEvent = new CloudEvent(
+                CloudEventsSpecVersion.V1_0,
+                "OrderCreatedEvent",
+                new Uri("http://test-host"),
+                operationId,
+                DateTime.UtcNow)
+            {
+                Data = eventData,
+                DataContentType = new ContentType("application/json")
+            };
+
+            await _eventGridPublisher.PublishAsync(orderCreatedEvent);
+
+            _logger.LogInformation("Event {EventId} was published with subject {EventSubject}", orderCreatedEvent.Id, orderCreatedEvent.Subject);
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/Hosting/ServiceBus/TestMessagePumpService.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/Hosting/ServiceBus/TestMessagePumpService.cs
@@ -87,7 +87,7 @@ namespace Arcus.BackgroundJobs.Tests.Integration.Hosting.ServiceBus
             var operationId = Guid.NewGuid().ToString();
             var transactionId = Guid.NewGuid().ToString();
 
-            Order order = GenerateOrder();
+            Order order = OrderGenerator.GenerateOrder();
             ServiceBusMessage orderMessage = order.AsServiceBusMessage(operationId, transactionId);
             orderMessage.ApplicationProperties["Topic"] = "Orders";
             await SendMessageToServiceBusAsync(connectionString, orderMessage);
@@ -109,21 +109,6 @@ namespace Arcus.BackgroundJobs.Tests.Integration.Hosting.ServiceBus
             Assert.Equal(transactionId, orderCreatedEventData.CorrelationInfo.TransactionId);
             Assert.Equal(operationId, orderCreatedEventData.CorrelationInfo.OperationId);
             Assert.NotEmpty(orderCreatedEventData.CorrelationInfo.CycleId);
-        }
-        
-        public static Order GenerateOrder()
-        {
-            var customerGenerator = new Faker<Customer>()
-                .RuleFor(u => u.FirstName, (f, u) => f.Name.FirstName())
-                .RuleFor(u => u.LastName, (f, u) => f.Name.LastName());
-
-            var orderGenerator = new Faker<Order>()
-                .RuleFor(u => u.Customer, () => customerGenerator)
-                .RuleFor(u => u.Id, f => Guid.NewGuid().ToString())
-                .RuleFor(u => u.Amount, f => f.Random.Int())
-                .RuleFor(u => u.ArticleNumber, f => f.Commerce.Product());
-
-            return orderGenerator.Generate();
         }
 
         /// <summary>


### PR DESCRIPTION
Provide the message pump/background job messaging options via the CloudEvents extensions.

Relates to https://github.com/arcus-azure/arcus.backgroundjobs/pull/74