### PR TITLE
docs: mention to use a recent `npm` version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ cd docs
 npm install
 ```
 
+> Make sure to have a recent version of `npm`. Worked in v7.21.0.
+
 ## Local Development
 
 ```console

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ cd docs
 npm install
 ```
 
-> Make sure to have a recent version of `npm`. Worked in v7.21.0.
+> You need at least version v7.21.0 of `npm`.
 
 ## Local Development
 


### PR DESCRIPTION
We should mention in the feature documentation to use a recent version of `npm`, as older versions gave errors.

Relates to https://github.com/arcus-azure/arcus/issues/155