### PR TITLE
feat: make az keyvault background jobs configurable

### DIFF
--- a/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests.cs
@@ -136,7 +136,6 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
 
                 Assert.True(expected == actual, $"Azure Service Bus topic subscription was not created/deleted as expected {expected} != {actual} when topic subscription '{topicSubscription}'");
             }
-            
         }
 
         private static SecretClient CreateKeyVaultClient(string tenantId, string keyVaultUri, string applicationId, string clientKey)

--- a/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests.cs
@@ -5,9 +5,13 @@ using Arcus.BackgroundJobs.Tests.Integration.Hosting;
 using Arcus.BackgroundJobs.Tests.Integration.Hosting.ServiceBus;
 using Arcus.BackgroundJobs.Tests.Integration.KeyVault.Fixture;
 using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Pumps.ServiceBus;
 using Arcus.Security.Providers.AzureKeyVault.Authentication;
 using Arcus.Testing.Logging;
+using Azure;
 using Azure.Identity;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Management.ServiceBus.Models;
@@ -23,6 +27,8 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
     [Trait("Category", "Integration")]
     public class AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests
     {
+        private const string ConnectionStringSecretKey = "ARCUS_KEYVAULT_SECRETNEWVERSIONCREATED_CONNECTIONSTRING";
+        
         private readonly ILogger _logger;
         
         /// <summary>
@@ -43,7 +49,6 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
             var applicationId = config.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
             var clientKey = config.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
             var keyVaultUri = config.GetValue<string>("Arcus:KeyVault:Uri");
-            
             _logger.LogInformation("Using Service Principal [ClientID: '{0}']", applicationId);
 
             var client = new ServiceBusConfiguration(rotationConfig, _logger);
@@ -52,11 +57,9 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
             SecretClient keyVaultClient = CreateKeyVaultClient(tenantId, keyVaultUri, applicationId, clientKey);
             await keyVaultClient.SetSecretAsync(rotationConfig.KeyVault.SecretName, freshConnectionString);
 
-            string jobId = Guid.NewGuid().ToString();
-            const string connectionStringSecretKey = "ARCUS_KEYVAULT_SECRETNEWVERSIONCREATED_CONNECTIONSTRING";
-
+            var jobId = Guid.NewGuid().ToString();
             var options = new WorkerOptions();
-            options.Configuration.Add(connectionStringSecretKey, rotationConfig.KeyVault.SecretNewVersionCreated.ConnectionString);
+            options.Configuration.Add(ConnectionStringSecretKey, rotationConfig.KeyVault.SecretNewVersionCreated.ConnectionString);
             AddEventGridPublisher(options, config);
             AddSecretStore(options, tenantId, keyVaultUri, applicationId, clientKey);
             AddServiceBusMessagePump(options, rotationConfig, jobId);
@@ -64,7 +67,7 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
             options.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
                 jobId: jobId,
                 subscriptionNamePrefix: "TestSub",
-                serviceBusTopicConnectionStringSecretKey: connectionStringSecretKey,
+                serviceBusTopicConnectionStringSecretKey: ConnectionStringSecretKey,
                 messagePumpConnectionStringKey: rotationConfig.KeyVault.SecretName);
 
             await using (var worker = await Worker.StartNewAsync(options))
@@ -81,6 +84,59 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
                     await service.SimulateMessageProcessingAsync(newPrimaryConnectionString);
                 }
             }
+        }
+
+        [Theory]
+        [InlineData(TopicSubscription.None, false)]
+        [InlineData(TopicSubscription.CreateOnStart, true)]
+        [InlineData(TopicSubscription.DeleteOnStop, false)]
+        [InlineData(TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop, true)]
+        public async Task AutoRestartServiceBusMessagePump_WithTopicSubscriptionInOptions_UsesOptions(
+            TopicSubscription topicSubscription,
+            bool expected)
+        {
+            var config = TestConfig.Create();
+            KeyRotationConfig rotationConfig = config.GetKeyRotationConfig();
+            var options = new WorkerOptions();
+            options.Configuration.Add(ConnectionStringSecretKey, rotationConfig.KeyVault.SecretNewVersionCreated.ConnectionString);
+            
+            var tenantId = config.GetValue<string>("Arcus:KeyRotation:ServiceBus:TenantId");
+            var applicationId = config.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
+            var clientKey = config.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
+            var keyVaultUri = config.GetValue<string>("Arcus:KeyVault:Uri");
+            var jobId = Guid.NewGuid().ToString();
+
+            AddSecretStore(options, tenantId, keyVaultUri, applicationId, clientKey);
+
+            var subscriptionPrefix = "AutoRestart";
+            options.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                jobId: jobId,
+                subscriptionNamePrefix: subscriptionPrefix,
+                serviceBusTopicConnectionStringSecretKey: ConnectionStringSecretKey,
+                messagePumpConnectionStringKey: rotationConfig.KeyVault.SecretName,
+                opt => opt.TopicSubscription = topicSubscription);
+
+            // Act
+            await using (var worker = await Worker.StartNewAsync(options))
+            {
+                // Assert
+                var client = new ServiceBusAdministrationClient(rotationConfig.KeyVault.SecretNewVersionCreated.ConnectionString);
+                var properties = ServiceBusConnectionStringProperties.Parse(rotationConfig.KeyVault.SecretNewVersionCreated.ConnectionString);
+
+                bool actual = false;
+                AsyncPageable<SubscriptionProperties> subscriptions = client.GetSubscriptionsAsync(properties.EntityPath);
+                await foreach (SubscriptionProperties sub in subscriptions)
+                {
+                    if (sub.SubscriptionName.StartsWith(subscriptionPrefix))
+                    {
+                        await client.DeleteSubscriptionAsync(properties.EntityPath, sub.SubscriptionName);
+                        actual = true;
+                    }
+                }
+
+                Assert.True(expected == actual, $"Azure Service Bus topic subscription was not created/deleted as expected {expected} != {actual} when topic subscription '{topicSubscription}'");
+            }
+            
         }
 
         private static SecretClient CreateKeyVaultClient(string tenantId, string keyVaultUri, string applicationId, string clientKey)

--- a/src/Arcus.BackgroundJobs.Tests.Unit/KeyVault/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Unit/KeyVault/IServiceCollectionExtensionsTests.cs
@@ -153,5 +153,75 @@ namespace Arcus.BackgroundJobs.Tests.Unit.KeyVault
                     "<service-bus-connection-string-secret-key>",
                     messagePumpConnectionStringKey));
         }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJobOptions_WithoutJobId_Fails(string jobId)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                services.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                    jobId,
+                    "<topic-subscription-prefix>",
+                    "<service-bus-connection-string-secret-key>",
+                    "<message-pump-connection-string-key>",
+                    configureBackgroundJob: null));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJobOptions_WithoutTopicSubscriptionPrefix_Fails(string topicSubscriptionPrefix)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                services.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                    "<job-id>",
+                    topicSubscriptionPrefix,
+                    "<service-bus-connection-string-secret-key>",
+                    "<message-pump-connection-string-key>",
+                    configureBackgroundJob: null));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJobOptions_WithoutServiceBusConnectionStringSecretKey_Fails(
+            string serviceBusConnectionStringSecretKey)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                services.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                    "<job-id>",
+                    "<topic-subscription-prefix>",
+                    serviceBusConnectionStringSecretKey,
+                    "<message-pump-connection-string-key>",
+                    configureBackgroundJob: null));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJobOptions_WithoutMessagePumpConnectionStringKey_Fails(
+            string messagePumpConnectionStringKey)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                services.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                    "<job-id>",
+                    "<topic-subscription-prefix>",
+                    "<service-bus-connection-string-secret-key>",
+                    messagePumpConnectionStringKey,
+                    configureBackgroundJob: null));
+        }
     }
 }


### PR DESCRIPTION
Make the auto restart Azure Service Bus message pump on Azure Key Vault secrets a configurable background job.

Closes #82 