### PR TITLE
docs: add Azure Active Directory background jobs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Background job development in a breeze.
 # Installation
 Easy to install it via NuGet:
 
+- **Azure Active Directory background jobs**
+
+```shell
+PM > Install-Package Arcus.BackgroundJobs.AzureActiveDirectory
+```
+
 - **CloudEvents background jobs**
 
 ```shell


### PR DESCRIPTION
Add the newly added project for Azure Active Directory background jobs to the README file.

Closes #97 