### PR TITLE
fix: add dedicated auto restart extension

### DIFF
--- a/docs/preview/02-Features/02-Security/auto-restart-servicebus-messagepump-on-rotated-credentials.md
+++ b/docs/preview/02-Features/02-Security/auto-restart-servicebus-messagepump-on-rotated-credentials.md
@@ -38,23 +38,22 @@ public class Startup
     
         string secretName = hostContext.Configuration["ARCUS_KEYVAULT_CONNECTIONSTRINGSECRETNAME"];
         services.AddServiceBusQueueMessagePump(secretName, options => options.JobId =   
-                .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
-
-         // This extension will be available to you once you installed the package.
-         services.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
-             jobId: jobId, 
-             subscriptionNamePrefix: "TestSub", 
-             
-             // The secret key where the Azure Service Bus Topic connection string is located that the background job will use to receive the Azure Key vault events.
-             serviceBusTopicConnectionStringSecretKey: "ARCUS_KEYVAULT_SECRETNEWVERSIONCREATED_CONNECTIONSTRING",
-             
-             // The secret key where the Azure Service Bus connection string is located that your target message pump uses.
-             // This secret key name will be used to check if the received Azure Key Vault event is from this secret or not.
-             messagePumpConnectionStringKey: secretName,
-    
-             // The maximum amount of thrown unauthorized exceptions that your message pump should allow before it should restart either way.
-             // This amount can be used to either wait for an Azure Key Vault event or rely on the thrown unauthorized exceptions.
-             maximumUnauthorizedExceptionsBeforeRestart: 5)
+                .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>()
+                // This extension will be available to you once you installed the package.
+                .WithAutoRestartOnRotatedCredentials(
+                     jobId: jobId, 
+                     subscriptionNamePrefix: "TestSub", 
+                     
+                     // The secret key where the Azure Service Bus Topic connection string is located that the background job will use to receive the Azure Key vault events.
+                     serviceBusTopicConnectionStringSecretKey: "ARCUS_KEYVAULT_SECRETNEWVERSIONCREATED_CONNECTIONSTRING",
+                     
+                     // The secret key where the Azure Service Bus connection string is located that your target message pump uses.
+                     // This secret key name will be used to check if the received Azure Key Vault event is from this secret or not.
+                     messagePumpConnectionStringKey: secretName,
+                     
+                     // The maximum amount of thrown unauthorized exceptions that your message pump should allow before it should restart either way.
+                     // This amount can be used to either wait for an Azure Key Vault event or rely on the thrown unauthorized exceptions.
+                     maximumUnauthorizedExceptionsBeforeRestart: 5);
     }
 }
 ```

--- a/docs/preview/02-Features/02-Security/auto-restart-servicebus-messagepump-on-rotated-credentials.md
+++ b/docs/preview/02-Features/02-Security/auto-restart-servicebus-messagepump-on-rotated-credentials.md
@@ -8,6 +8,8 @@ layout: default
 The library `Arcus.BackgroundJobs.KeyVault` provides an extension on the message pump to restart the pump automatically when the credentials of the pump stored in Azure Key Vault are changed.
 This feature allows more reliable restarting instead of relying on authentication exceptions that may be thrown during the lifetime of the message pump.
 
+See [Arcus message handling](https://messaging.arcus-azure.net/) for more information on message pumps and message handling.
+
 ## How does this work?
 
 A background job is polling for `SecretNewVersionCreated` events on an Azure Service Bus Topic for the secret that stores the connection string.
@@ -24,20 +26,26 @@ PM > Install-Package Arcus.BackgroundJobs.KeyVault
 
 ### Usage
 
-When the package is installed, you'll be able to use the extension in your application:
+When the package is installed, you'll be able to use the extension in your application. Make sure that you have registered the [Arcus secret store](https://security.arcus-azure.net/features/secret-store/) so the background job on which Azure Service Bus topic subscription it has to receive Azure Key vault events.
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
 
-public class Startup
+public class Program
 {
-    public void ConfigureServices(IServiceCollection services)
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
+        services.AddSecretStore(stores =>
+        {
+            string keyVaultName = configuration["ARCUS_KEYVAULT_NAME"];
+            stores.AddAzureKeyVaultWithManagedServiceIdentity($"https://{keyVaultName}.vault.azure.net");
+        });
+
         // You should have a unique Job ID to identity the message pump so the automatic process knows which pump to restart.
         string jobId = Guid.NewGuid().ToString();
     
-        string secretName = hostContext.Configuration["ARCUS_KEYVAULT_CONNECTIONSTRINGSECRETNAME"];
-        services.AddServiceBusQueueMessagePump(secretName, options => options.JobId =   
+        string secretName = configuration["ARCUS_KEYVAULT_CONNECTIONSTRINGSECRETNAME"];
+        services.AddServiceBusQueueMessagePump(secretName, options => options.JobId = jobId)
                 .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>()
                 // This extension will be available to you once you installed the package.
                 .WithAutoRestartOnRotatedCredentials(

--- a/src/Arcus.BackgroundJobs.AzureActiveDirectory/Arcus.BackgroundJobs.AzureActiveDirectory.csproj
+++ b/src/Arcus.BackgroundJobs.AzureActiveDirectory/Arcus.BackgroundJobs.AzureActiveDirectory.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Arcus.BackgroundJobs.KeyVault/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.BackgroundJobs.KeyVault/Extensions/IServiceCollectionExtensions.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.
         /// </exception>
-        [Obsolete("Consider using the " + nameof(Arcus.BackgroundJobs.KeyVault.Extensions.ServiceBusMessageHandlerCollectionExtensions.WithAutoRestartOnRotatedCredentials) + " extension instead when configuring the message pump/router/handlers")]
         public static IServiceCollection AddAutoInvalidateKeyVaultSecretBackgroundJob(
             this IServiceCollection services,
             string subscriptionNamePrefix,
@@ -50,7 +49,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.
         /// </exception>
-        [Obsolete("Consider using the " + nameof(Arcus.BackgroundJobs.KeyVault.Extensions.ServiceBusMessageHandlerCollectionExtensions.WithAutoRestartOnRotatedCredentials) + " extension instead when configuring the message pump/router/handlers")]
         public static IServiceCollection AddAutoInvalidateKeyVaultSecretBackgroundJob(
             this IServiceCollection services,
             string subscriptionNamePrefix,
@@ -90,6 +88,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.
         /// </exception>
+#pragma warning disable CS0436 // Type conflicts with imported type
+        [Obsolete("Consider using the " + nameof(ServiceBusMessageHandlerCollectionExtensions.WithAutoRestartOnRotatedCredentials) + " extension instead when configuring the message pump/router/handlers")]
+#pragma warning restore CS0436 // Type conflicts with imported type
         public static IServiceCollection AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
             this IServiceCollection services,
             string jobId,
@@ -111,7 +112,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 messagePumpConnectionStringKey,
                 configureBackgroundJob: null);
         }
-        
+
         /// <summary>
         /// Adds a background job to the <see cref="IServiceCollection"/> to automatically restart a <see cref="AzureServiceBusMessagePump"/> with a specific <paramref name="jobId"/>
         /// when the Azure Key Vault secret that holds the Azure Service Bus connection string was updated.
@@ -133,6 +134,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.
         /// </exception>
+#pragma warning disable CS0436 // Type conflicts with imported type
+        [Obsolete("Consider using the " + nameof(Microsoft.Extensions.DependencyInjection.ServiceBusMessageHandlerCollectionExtensions.WithAutoRestartOnRotatedCredentials) + " extension instead when configuring the message pump/router/handlers")]
+#pragma warning restore CS0436 // Type conflicts with imported type
         public static IServiceCollection AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
             this IServiceCollection services,
             string jobId,

--- a/src/Arcus.BackgroundJobs.KeyVault/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.BackgroundJobs.KeyVault/Extensions/IServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.
         /// </exception>
+        [Obsolete("Consider using the " + nameof(Arcus.BackgroundJobs.KeyVault.Extensions.ServiceBusMessageHandlerCollectionExtensions.WithAutoRestartOnRotatedCredentials) + " extension instead when configuring the message pump/router/handlers")]
         public static IServiceCollection AddAutoInvalidateKeyVaultSecretBackgroundJob(
             this IServiceCollection services,
             string subscriptionNamePrefix,
@@ -49,6 +50,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.
         /// </exception>
+        [Obsolete("Consider using the " + nameof(Arcus.BackgroundJobs.KeyVault.Extensions.ServiceBusMessageHandlerCollectionExtensions.WithAutoRestartOnRotatedCredentials) + " extension instead when configuring the message pump/router/handlers")]
         public static IServiceCollection AddAutoInvalidateKeyVaultSecretBackgroundJob(
             this IServiceCollection services,
             string subscriptionNamePrefix,

--- a/src/Arcus.BackgroundJobs.KeyVault/Extensions/ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.BackgroundJobs.KeyVault/Extensions/ServiceBusMessageHandlerCollectionExtensions.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.Configuration;
+using CloudNative.CloudEvents;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extensions on the <see cref="ServiceBusMessageHandlerCollection"/> to make the registration of background jobs more dev-friendly.
+    /// </summary>
+    public static class ServiceBusMessageHandlerCollectionExtensions
+    {
+        /// <summary>
+        /// Adds a background job to the <see cref="IServiceCollection"/> to automatically restart a <see cref="AzureServiceBusMessagePump"/> with a specific <paramref name="jobId"/>
+        /// when the Azure Key Vault secret that holds the Azure Service Bus connection string was updated.
+        /// </summary>
+        /// <param name="services">The collection of services to add the job to.</param>
+        /// <param name="jobId">The unique background job ID to identify which message pump to restart.</param>
+        /// <param name="subscriptionNamePrefix">The name of the Azure Service Bus subscription that will be created to receive <see cref="CloudEvent"/>'s.</param>
+        /// <param name="serviceBusTopicConnectionStringSecretKey">The secret key that points to the Azure Service Bus Topic connection string.</param>
+        /// <param name="messagePumpConnectionStringKey">
+        ///     The secret key where the connection string credentials are located for the target message pump that needs to be auto-restarted.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="services"/> or the searched for <see cref="AzureServiceBusMessagePump"/> based on the given <paramref name="jobId"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.
+        /// </exception>
+        public static ServiceBusMessageHandlerCollection WithAutoRestartOnRotatedCredentials(
+            this ServiceBusMessageHandlerCollection services,
+            string jobId,
+            string subscriptionNamePrefix,
+            string serviceBusTopicConnectionStringSecretKey,
+            string messagePumpConnectionStringKey)
+        {
+            return WithAutoRestartOnRotatedCredentials(
+                services, jobId, subscriptionNamePrefix, serviceBusTopicConnectionStringSecretKey, messagePumpConnectionStringKey, configureBackgroundJob: null);
+        }
+
+        /// <summary>
+        /// Adds a background job to the <see cref="IServiceCollection"/> to automatically restart a <see cref="AzureServiceBusMessagePump"/> with a specific <paramref name="jobId"/>
+        /// when the Azure Key Vault secret that holds the Azure Service Bus connection string was updated.
+        /// </summary>
+        /// <param name="services">The collection of services to add the job to.</param>
+        /// <param name="jobId">The unique background job ID to identify which message pump to restart.</param>
+        /// <param name="subscriptionNamePrefix">The name of the Azure Service Bus subscription that will be created to receive <see cref="CloudEvent"/>'s.</param>
+        /// <param name="serviceBusTopicConnectionStringSecretKey">The secret key that points to the Azure Service Bus Topic connection string.</param>
+        /// <param name="messagePumpConnectionStringKey">
+        ///     The secret key where the connection string credentials are located for the target message pump that needs to be auto-restarted.
+        /// </param>
+        /// <param name="configureBackgroundJob">
+        ///     The capability to configure additional options on how the auto-restart Azure Service Bus message pump
+        ///     on rotated Azure Key Vault credentials background job should behave.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="services"/> or the searched for <see cref="AzureServiceBusMessagePump"/> based on the given <paramref name="jobId"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.
+        /// </exception>
+        public static ServiceBusMessageHandlerCollection WithAutoRestartOnRotatedCredentials(
+            this ServiceBusMessageHandlerCollection services,
+            string jobId,
+            string subscriptionNamePrefix,
+            string serviceBusTopicConnectionStringSecretKey,
+            string messagePumpConnectionStringKey,
+            Action<IAzureServiceBusTopicMessagePumpOptions> configureBackgroundJob)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a collection of services to add the re-authentication background job");
+            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a non-blank job ID to identify the Azure Service Bus message pump which needs to restart");
+            Guard.NotNullOrWhitespace(subscriptionNamePrefix, nameof(subscriptionNamePrefix), "Requires a non-blank subscription name of the Azure Service Bus Topic subscription, to receive Azure Key Vault events");
+            Guard.NotNullOrWhitespace(serviceBusTopicConnectionStringSecretKey, nameof(serviceBusTopicConnectionStringSecretKey), "Requires a non-blank secret key that points to a Azure Service Bus Topic");
+            Guard.NotNullOrWhitespace(messagePumpConnectionStringKey, nameof(messagePumpConnectionStringKey), "Requires a non-blank secret key that points to the credentials that holds the connection string of the target message pump");
+
+#pragma warning disable CS0618 // Deprecated version still has the actual implementation, it can be moved to here once the next major version deletes the deprecated version.
+            services.Services.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+#pragma warning restore CS0618
+                jobId,
+                subscriptionNamePrefix,
+                serviceBusTopicConnectionStringSecretKey,
+                messagePumpConnectionStringKey,
+                configureBackgroundJob);
+
+            return services;
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/AutoRestartServiceBusMessagePumpOnRotatedCredentialsJobTests.cs
@@ -7,6 +7,7 @@ using Arcus.BackgroundJobs.Tests.Integration.Hosting;
 using Arcus.BackgroundJobs.Tests.Integration.KeyVault.Fixture;
 using Arcus.EventGrid;
 using Arcus.EventGrid.Contracts;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Pumps.ServiceBus;
 using Arcus.Testing.Logging;
 using Azure;
@@ -67,9 +68,8 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
                            opt.JobId = jobId;
                            // Unrealistic big maximum exception count so that we're certain that the message pump gets restarted based on the notification and not the unauthorized exception.
                            opt.MaximumUnauthorizedExceptionsBeforeRestart = 1000;
-                       }).WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
-                       
-                       services.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                       }).WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>()
+                         .WithAutoRestartOnRotatedCredentials(
                            jobId: jobId,
                            subscriptionNamePrefix: "TestSub",
                            serviceBusTopicConnectionStringSecretKey: ConnectionStringSecretKey,
@@ -121,7 +121,8 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
                     stores.AddInMemory(ConnectionStringSecretKey, rotationConfig.KeyVault.SecretNewVersionCreated.ConnectionString)
                           .AddAzureKeyVaultWithServicePrincipal(config);
                 });
-                services.AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob(
+                var collection = new ServiceBusMessageHandlerCollection(services);
+                collection.WithAutoRestartOnRotatedCredentials(
                     jobId: Guid.NewGuid().ToString(),
                     subscriptionNamePrefix: subscriptionPrefix,
                     serviceBusTopicConnectionStringSecretKey: ConnectionStringSecretKey,

--- a/src/Arcus.BackgroundJobs.Tests.Unit/KeyVault/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Unit/KeyVault/IServiceCollectionExtensionsTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
+#pragma warning disable CS0618
 
 namespace Arcus.BackgroundJobs.Tests.Unit.KeyVault
 {

--- a/src/Arcus.BackgroundJobs.Tests.Unit/KeyVault/ServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Unit/KeyVault/ServiceCollectionExtensionsTests.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Arcus.BackgroundJobs.KeyVault.Extensions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;

--- a/src/Arcus.BackgroundJobs.Tests.Unit/KeyVault/ServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Unit/KeyVault/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Arcus.BackgroundJobs.KeyVault.Extensions;
+using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.Configuration;
+using Azure.Identity;
+using CloudNative.CloudEvents;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Arcus.BackgroundJobs.Tests.Unit.KeyVault
+{
+    [Trait("Category", "Unit")]
+    public class ServiceCollectionExtensionsTests
+    {
+        [Fact]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob_WithoutReferencingMessagePump_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new ServiceBusMessageHandlerCollection(services);
+            services.AddSingleton(Mock.Of<IConfiguration>());
+            services.AddLogging();
+            services.AddSingleton<IHostedService>(serviceProvider =>
+            {
+                var settings = new AzureServiceBusMessagePumpSettings(
+                    "<entity-name>",
+                    "<subscription-name>",
+                    ServiceBusEntityType.Queue,
+                    "<service-bus-namespace>",
+                    new DefaultAzureCredential(),
+                    new AzureServiceBusMessagePumpOptions { JobId = "No-the-same-job-id" },
+                    serviceProvider);
+
+                return new AzureServiceBusMessagePump(
+                    settings,
+                    Mock.Of<IConfiguration>(),
+                    serviceProvider,
+                    Mock.Of<IAzureServiceBusMessageRouter>(),
+                    NullLogger<AzureServiceBusMessagePump>.Instance);
+            });
+
+            // Act
+            collection.WithAutoRestartOnRotatedCredentials(
+                "<non-existing-job-id>",
+                "<topic-subscription-prefix>",
+                "<service-bus-topic-connection-string-secret-key>",
+                "<message-pump-connection-string-key>");
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            Assert.ThrowsAny<InvalidOperationException>(
+                () => provider.GetRequiredService<IMessageHandler<CloudEvent, AzureServiceBusMessageContext>>());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob_WithoutJobId_Fails(string jobId)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new ServiceBusMessageHandlerCollection(services);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                collection.WithAutoRestartOnRotatedCredentials(
+                    jobId,
+                    "<topic-subscription-prefix>",
+                    "<service-bus-connection-string-secret-key>",
+                    "<message-pump-connection-string-key>"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob_WithoutTopicSubscriptionPrefix_Fails(string topicSubscriptionPrefix)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new ServiceBusMessageHandlerCollection(services);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                collection.WithAutoRestartOnRotatedCredentials(
+                    "<job-id>",
+                    topicSubscriptionPrefix,
+                    "<service-bus-connection-string-secret-key>",
+                    "<message-pump-connection-string-key>"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob_WithoutServiceBusConnectionStringSecretKey_Fails(
+            string serviceBusConnectionStringSecretKey)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new ServiceBusMessageHandlerCollection(services);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                collection.WithAutoRestartOnRotatedCredentials(
+                    "<job-id>",
+                    "<topic-subscription-prefix>",
+                    serviceBusConnectionStringSecretKey,
+                    "<message-pump-connection-string-key>"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJob_WithoutMessagePumpConnectionStringKey_Fails(
+            string messagePumpConnectionStringKey)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new ServiceBusMessageHandlerCollection(services);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                collection.WithAutoRestartOnRotatedCredentials(
+                    "<job-id>",
+                    "<topic-subscription-prefix>",
+                    "<service-bus-connection-string-secret-key>",
+                    messagePumpConnectionStringKey));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJobOptions_WithoutJobId_Fails(string jobId)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new ServiceBusMessageHandlerCollection(services);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                collection.WithAutoRestartOnRotatedCredentials(
+                    jobId,
+                    "<topic-subscription-prefix>",
+                    "<service-bus-connection-string-secret-key>",
+                    "<message-pump-connection-string-key>",
+                    configureBackgroundJob: null));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJobOptions_WithoutTopicSubscriptionPrefix_Fails(string topicSubscriptionPrefix)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new ServiceBusMessageHandlerCollection(services);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                collection.WithAutoRestartOnRotatedCredentials(
+                    "<job-id>",
+                    topicSubscriptionPrefix,
+                    "<service-bus-connection-string-secret-key>",
+                    "<message-pump-connection-string-key>",
+                    configureBackgroundJob: null));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJobOptions_WithoutServiceBusConnectionStringSecretKey_Fails(
+            string serviceBusConnectionStringSecretKey)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new ServiceBusMessageHandlerCollection(services);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                collection.WithAutoRestartOnRotatedCredentials(
+                    "<job-id>",
+                    "<topic-subscription-prefix>",
+                    serviceBusConnectionStringSecretKey,
+                    "<message-pump-connection-string-key>",
+                    configureBackgroundJob: null));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAutoRestartServiceBusMessagePumpOnRotatedCredentialsBackgroundJobOptions_WithoutMessagePumpConnectionStringKey_Fails(
+            string messagePumpConnectionStringKey)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new ServiceBusMessageHandlerCollection(services);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                collection.WithAutoRestartOnRotatedCredentials(
+                    "<job-id>",
+                    "<topic-subscription-prefix>",
+                    "<service-bus-connection-string-secret-key>",
+                    messagePumpConnectionStringKey,
+                    configureBackgroundJob: null));
+        }
+    }
+}


### PR DESCRIPTION
Adds dedicated extension for the adding of the auto-restart message pump on rotated Azure Key Vault credentials.

Closes #109