### PR TITLE
chore: add readme and proj url to nuget pkg

### DIFF
--- a/src/Arcus.BackgroundJobs.AzureActiveDirectory/Arcus.BackgroundJobs.AzureActiveDirectory.csproj
+++ b/src/Arcus.BackgroundJobs.AzureActiveDirectory/Arcus.BackgroundJobs.AzureActiveDirectory.csproj
@@ -9,7 +9,7 @@
     <Description>Provides capabilities for running background jobs to automate the notification of expiring client secrets of applications in Azure Active Directory.</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.backgroundjobs/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.backgroundjobs</PackageProjectUrl>
+    <PackageProjectUrl>https://background-jobs.arcus-azure.net/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.backgroundjobs</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -17,6 +17,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Arcus.EventGrid.Publishing" Version="[3.2.0, 4.0.0)" />

--- a/src/Arcus.BackgroundJobs.AzureAppConfiguration/Arcus.BackgroundJobs.AzureAppConfiguration.csproj
+++ b/src/Arcus.BackgroundJobs.AzureAppConfiguration/Arcus.BackgroundJobs.AzureAppConfiguration.csproj
@@ -9,7 +9,7 @@
     <Description>Provides capabilities for running background jobs to automate operations on Azure App Configuration.</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.backgroundjobs/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.backgroundjobs</PackageProjectUrl>
+    <PackageProjectUrl>https://background-jobs.arcus-azure.net/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.backgroundjobs</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -17,6 +17,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Arcus.EventGrid" Version="[3.2.0,4.0.0)" />

--- a/src/Arcus.BackgroundJobs.CloudEvents/Arcus.BackgroundJobs.CloudEvents.csproj
+++ b/src/Arcus.BackgroundJobs.CloudEvents/Arcus.BackgroundJobs.CloudEvents.csproj
@@ -9,7 +9,7 @@
     <Description>Provides capabilities for running background jobs to automate workflows.</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.backgroundjobs/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.backgroundjobs</PackageProjectUrl>
+    <PackageProjectUrl>https://background-jobs.arcus-azure.net/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.backgroundjobs</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -17,6 +17,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Arcus.EventGrid" Version="[3.2.0,4.0.0)" />

--- a/src/Arcus.BackgroundJobs.Databricks/Arcus.BackgroundJobs.Databricks.csproj
+++ b/src/Arcus.BackgroundJobs.Databricks/Arcus.BackgroundJobs.Databricks.csproj
@@ -9,7 +9,7 @@
     <Description>Provides capabilities for running background jobs to automate Databricks workflows.</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.backgroundjobs/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.backgroundjobs</PackageProjectUrl>
+    <PackageProjectUrl>https://background-jobs.arcus-azure.net/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.backgroundjobs</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -17,6 +17,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.4.0,3.0.0)" />

--- a/src/Arcus.BackgroundJobs.KeyVault/Arcus.BackgroundJobs.KeyVault.csproj
+++ b/src/Arcus.BackgroundJobs.KeyVault/Arcus.BackgroundJobs.KeyVault.csproj
@@ -9,7 +9,7 @@
     <Description>Provides capabilities for running background jobs to automate workflows such as updating cached Azure Key Value secrets.</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.backgroundjobs/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.backgroundjobs</PackageProjectUrl>
+    <PackageProjectUrl>https://background-jobs.arcus-azure.net/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.backgroundjobs</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -17,6 +17,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Arcus.EventGrid" Version="[3.2.0,4.0.0)" />


### PR DESCRIPTION
Adds the GitHub README file to the NuGet package generation of the projects.
Adds feature docs project URL instead of GitHub URL to NuGet package.

Relates to arcus-azure/arcus#209
Relates to arcus-azure/arcus#208