### PR TITLE
fix: remove invalid exn handling

### DIFF
--- a/src/Arcus.BackgroundJobs.AzureActiveDirectory/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.BackgroundJobs.AzureActiveDirectory/Extensions/IServiceCollectionExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Arcus.BackgroundJobs.AzureActiveDirectory;
 using GuardNet;
-using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -36,17 +33,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     options.SetUserOptions(additionalOptions);
                 });
-                builder.UnobservedTaskExceptionHandler = (sender, args) =>  UnobservedExceptionHandler(args, services);
             });
-        }
-
-        private static void UnobservedExceptionHandler(UnobservedTaskExceptionEventArgs eventArgs, IServiceCollection services)
-        {
-            ServiceDescriptor logger = services.FirstOrDefault(service => service.ServiceType == typeof(ILogger));
-            var loggerInstance = (ILogger) logger?.ImplementationInstance;
-
-            loggerInstance?.LogCritical(eventArgs.Exception, "Unhandled exception in job {JobName}", nameof(ClientSecretExpirationJob));
-            eventArgs.SetObserved();
         }
     }
 }

--- a/src/Arcus.BackgroundJobs.Databricks/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.BackgroundJobs.Databricks/Extensions/IServiceCollectionExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Arcus.BackgroundJobs.Databricks;
 using GuardNet;
-using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -45,17 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     options.TokenSecretKey = tokenSecretKey;
                     options.SetUserOptions(additionalOptions);
                 });
-                builder.UnobservedTaskExceptionHandler = (sender, args) =>  UnobservedExceptionHandler(args, services);
             });
-        }
-
-        private static void UnobservedExceptionHandler(UnobservedTaskExceptionEventArgs eventArgs, IServiceCollection services)
-        {
-            ServiceDescriptor logger = services.FirstOrDefault(service => service.ServiceType == typeof(ILogger));
-            var loggerInstance = (ILogger) logger?.ImplementationInstance;
-
-            loggerInstance?.LogCritical(eventArgs.Exception, "Unhandled exception in job {JobName}", nameof(DatabricksJobMetricsJob));
-            eventArgs.SetObserved();
         }
     }
 }


### PR DESCRIPTION
Remove the attempt to log on unobserved exceptions.
We tried to retrieve back the registered logging system, but this is not only wrong, it is rather unstable.

We can either remove this, like in this PR, so that the consumers can see directly what's wrong with their scheduled job (authentication, processing failures...)
Or we can come up with a more resilient scheduled job that logs critical errors for unhandled exceptions in the scheduled job instead on relying on the incomplete 'unobsered exception handling'.

See also https://github.com/kdcllc/CronScheduler.AspNetCore/issues/47 and https://github.com/kdcllc/CronScheduler.AspNetCore/pull/48