### PR TITLE
chore: mark unnecessary cloudevents options as obsolete

### DIFF
--- a/src/Arcus.BackgroundJobs.CloudEvents/CloudEventBackgroundJobOptions.cs
+++ b/src/Arcus.BackgroundJobs.CloudEvents/CloudEventBackgroundJobOptions.cs
@@ -1,8 +1,12 @@
-﻿namespace Arcus.BackgroundJobs.CloudEvents
+﻿using System;
+using Arcus.Messaging.Pumps.ServiceBus.Configuration;
+
+namespace Arcus.BackgroundJobs.CloudEvents
 {
     /// <summary>
     /// Represents the options to configure the <see cref="CloudEventBackgroundJob"/>.
     /// </summary>
+    [Obsolete("Configuring the CloudEvents background job now happens with a dedicated Azure Service Bus topic set of options '" + nameof(IAzureServiceBusTopicMessagePumpOptions) + "' when registering the job")]
     public class CloudEventBackgroundJobOptions
     {
         /// <summary>


### PR DESCRIPTION
Since we now use the message router to handle deserialization, there's no need for a dedicated message pump for the CloudEvents background jobs, and therefore, no need for a dedicated set of options. These options were not removed during this migration because of backwards-compatibility, but should be marked as deprecated.