### PR TITLE
test/use own spy secret provider

### DIFF
--- a/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/AutoInvalidateKeyVaultSecretJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/AutoInvalidateKeyVaultSecretJobTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using Polly;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
 {
@@ -46,21 +47,14 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
             var client = new SecretClient(new Uri(keyVaultUri), credential);
 
             const string secretKey = "Arcus:KeyVault:SecretNewVersionCreated:ServiceBus:ConnectionStringWithTopic";
-            var cachedSecretProvider = new Mock<ICachedSecretProvider>();
-            cachedSecretProvider
-                .Setup(p => p.GetRawSecretAsync(secretKey))
-                .ReturnsAsync(() => _config[secretKey]);
-
-            cachedSecretProvider
-                .Setup(p => p.InvalidateSecretAsync(It.IsAny<string>()))
-                .Returns(Task.CompletedTask);
+            var spySecretProvider = new SpyCachedSecretProvider(_config[secretKey]);
             
             var options = new WorkerOptions();
             options.ConfigureLogging(_logger)
                    .ConfigureServices(services =>
                    {
-                       services.AddSingleton<ISecretProvider>(cachedSecretProvider.Object)
-                               .AddSingleton<ICachedSecretProvider>(cachedSecretProvider.Object)
+                       services.AddSingleton<ISecretProvider>(spySecretProvider)
+                               .AddSingleton<ICachedSecretProvider>(spySecretProvider)
                                .AddAutoInvalidateKeyVaultSecretBackgroundJob(
                                    subscriptionNamePrefix: "TestSub",
                                    serviceBusTopicConnectionStringSecretKey: secretKey);
@@ -75,7 +69,7 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
                 // Assert
                 RetryAssertion(
                     // ReSharper disable once AccessToDisposedClosure - disposal happens after retry.
-                    () => cachedSecretProvider.Verify(p => p.InvalidateSecretAsync(It.Is<string>(n => n == tempSecret.Name)), Times.Once), 
+                    () => Assert.True(spySecretProvider.IsSecretInvalidated), 
                     timeout: TimeSpan.FromMinutes(8),
                     interval: TimeSpan.FromMilliseconds(500));
             }
@@ -84,7 +78,7 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
         private static void RetryAssertion(Action assertion, TimeSpan timeout, TimeSpan interval)
         {
             Policy.Timeout(timeout)
-                  .Wrap(Policy.Handle<MockException>()
+                  .Wrap(Policy.Handle<XunitException>()
                               .WaitAndRetryForever(_ => interval))
                   .Execute(assertion);
         }

--- a/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/AutoInvalidateKeyVaultSecretJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/AutoInvalidateKeyVaultSecretJobTests.cs
@@ -47,7 +47,7 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault
             var client = new SecretClient(new Uri(keyVaultUri), credential);
 
             const string secretKey = "Arcus:KeyVault:SecretNewVersionCreated:ServiceBus:ConnectionStringWithTopic";
-            var spySecretProvider = new SpyCachedSecretProvider(_config[secretKey]);
+            var spySecretProvider = new SpyCachedSecretProvider(secretKey, _config[secretKey]);
             
             var options = new WorkerOptions();
             options.ConfigureLogging(_logger)

--- a/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/Fixture/SpyCachedSecretProvider.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/Fixture/SpyCachedSecretProvider.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
+using Arcus.Security.Core.Caching;
+using Arcus.Security.Core.Caching.Configuration;
+using GuardNet;
+
+namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault.Fixture
+{
+    /// <summary>
+    /// Represents a stubbed version of an <see cref="ICachedSecretProvider"/> that spies on invalidating secrets.
+    /// </summary>
+    public class SpyCachedSecretProvider : ICachedSecretProvider
+    {
+        private readonly string _staticSecretValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpyCachedSecretProvider" /> class.
+        /// </summary>
+        public SpyCachedSecretProvider(string staticSecretValue)
+        {
+            Guard.NotNull(staticSecretValue, nameof(staticSecretValue));
+            _staticSecretValue = staticSecretValue;
+        }
+
+        /// <summary>Gets the cache-configuration for this instance.</summary>
+        public ICacheConfiguration Configuration { get; }
+
+        /// <summary>
+        /// Gets the value indicating whether or not the secret name is invalidated.
+        /// </summary>
+        public bool IsSecretInvalidated { get; private set; }
+
+        /// <summary>Retrieves the secret value, based on the given name</summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns the secret key.</returns>
+        /// <exception cref="T:System.ArgumentException">The <paramref name="secretName" /> must not be empty</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="secretName" /> must not be null</exception>
+        /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
+        public Task<string> GetRawSecretAsync(string secretName)
+        {
+            return Task.FromResult(_staticSecretValue);
+        }
+
+        /// <summary>Retrieves the secret value, based on the given name</summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns a <see cref="T:Arcus.Security.Core.Secret" /> that contains the secret key</returns>
+        /// <exception cref="T:System.ArgumentException">The <paramref name="secretName" /> must not be empty</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="secretName" /> must not be null</exception>
+        /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
+        public Task<Secret> GetSecretAsync(string secretName)
+        {
+            return Task.FromResult(new Secret(_staticSecretValue));
+        }
+
+        /// <summary>Retrieves the secret value, based on the given name</summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <param name="ignoreCache">Indicates if the cache should be used or skipped</param>
+        /// <returns>Returns a <see cref="T:System.Threading.Tasks.Task`1" /> that contains the secret key</returns>
+        /// <exception cref="T:System.ArgumentException">The name must not be empty</exception>
+        /// <exception cref="T:System.ArgumentNullException">The name must not be null</exception>
+        /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
+        public Task<string> GetRawSecretAsync(string secretName, bool ignoreCache)
+        {
+            return Task.FromResult(_staticSecretValue);
+        }
+
+        /// <summary>Retrieves the secret value, based on the given name</summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <param name="ignoreCache">Indicates if the cache should be used or skipped</param>
+        /// <returns>Returns a <see cref="T:System.Threading.Tasks.Task`1" /> that contains the secret key</returns>
+        /// <exception cref="T:System.ArgumentException">The name must not be empty</exception>
+        /// <exception cref="T:System.ArgumentNullException">The name must not be null</exception>
+        /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
+        public Task<Secret> GetSecretAsync(string secretName, bool ignoreCache)
+        {
+            return Task.FromResult(new Secret(_staticSecretValue));
+        }
+
+        /// <summary>
+        /// Removes the secret with the given <paramref name="secretName" /> from the cache;
+        /// so the next time <see cref="M:Arcus.Security.Core.Caching.CachedSecretProvider.GetSecretAsync(System.String)" /> is called, a new version of the secret will be added back to the cache.
+        /// </summary>
+        /// <param name="secretName">The name of the secret that should be removed from the cache.</param>
+        public Task InvalidateSecretAsync(string secretName)
+        {
+            IsSecretInvalidated = secretName == _staticSecretValue;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/Fixture/SpyCachedSecretProvider.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/KeyVault/Fixture/SpyCachedSecretProvider.cs
@@ -101,7 +101,7 @@ namespace Arcus.BackgroundJobs.Tests.Integration.KeyVault.Fixture
         /// <param name="secretName">The name of the secret that should be removed from the cache.</param>
         public Task InvalidateSecretAsync(string secretName)
         {
-            IsSecretInvalidated = secretName == _staticSecretName;
+            IsSecretInvalidated = true;
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
We should make sure that we correctly assert invalidated secrets and that the results are the same locally as well as remotely.