### PR TITLE
feat: add managed identity support auto-refresh app config job

### DIFF
--- a/docs/preview/02-Features/05-AzureAppConfiguration/auto-refresh-app-configuration.md
+++ b/docs/preview/02-Features/05-AzureAppConfiguration/auto-refresh-app-configuration.md
@@ -21,14 +21,62 @@ We use the events from Azure App Configuration which will be send towards an Azu
 2. Create an Azure Service Bus Topic resource
 3. Create an event subscription on the App Configuration resource to send events to the Service Bus Topic
 
-
-
 ![Automatically refresh Azure App Configuration values](/media/Azure-App-Configuration-Job.png)
 
 Both the connection string of the Azure App Configuration and the Azure Service Bus Topic will be needed in the next section, so make sure you have those.
 
-## Usage
-Our background job requires both the configuration of Azure App Configuration while setting up the `IConfiguration`, 
+## Usage with managed identity
+When connecting to Azure App Configuration using managed identity, you only need to provide the Azure Service Bus topic name and namespace where the the Azure App Configuration events are placed:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        IHostBuilder hostBuilder = CreateHostBuilder(args);
+        hostBuilder.Build().Run();
+    }
+
+    private static IHostBuilder CreateHostBuilder(string[] args)
+    {
+        return Host.CreateDefaultBuilder(args)
+                    .ConfigureAppConfiguration(configBuilder => ConfigureAppConfiguration(configBuilder))
+                    .ConfigureServices(services => ConfigureServices(services));
+    }
+
+    private static void ConfigureAppConfiguration(IConfigurationBuilder configBuilder)
+    {
+        configBuilder.AddAzureAppConfiguration(appConfigOptions =>
+        {
+            appConfigOptions.Connect("<your-azure-app-configuration-endpoint>", new ManagedIdentityCredential())
+                            // Specifies which Azure App Configuration key you want to automatically updated.
+                            .Register("<your-azure-app-configuration-key>");
+        });
+    }
+
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Adds the automatic Azure App Configuration refresh background job
+        services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+            // The name of the Azure Service Bus topic where Azure App Configuration events are placed.
+            topicName: "<servicebus-topic-name>",
+            // The namespace of the Azure Service Bus topic where Azure App Configuration events are placed.
+            serviceBusNamespace: "<your-namespace>.servicebus.windows.net",
+            // Prefix of the Azure Service Bus Topic subscription;
+            //    this allows the background jobs to support applications that are running multiple instances, processing the same type of events, without conflicting subscription names.
+            subscriptionPrefix: "TestSub",
+            // The client ID to authenticate for a user assigned managed identity. More information on user assigned managed identities cam be found here:
+            // https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm.
+            clientId: null);
+    }
+}
+```
+
+## Usage with connection string
+When using a connection string to connect to Azure App Configuration, our background job requires both the configuration of Azure App Configuration while setting up the `IConfiguration`, 
 as well as the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) which will retrieve the connection string of the Azure Service Bus Topic.
 
 ```csharp
@@ -76,4 +124,6 @@ public class Program
 }
 ```
 
-[&larr; back](/)
+## Configuration
+The background job provides configuration options to alter the behavior of the internal message pump that processes the Azure App Configuration events. 
+These messaging options are explained in detail at the [Arcus messaging feature documentation](https://messaging.arcus-azure.net/Features/message-pumps/service-bus#configuration).

--- a/docs/preview/02-Features/05-AzureAppConfiguration/auto-refresh-app-configuration.md
+++ b/docs/preview/02-Features/05-AzureAppConfiguration/auto-refresh-app-configuration.md
@@ -26,7 +26,7 @@ We use the events from Azure App Configuration which will be send towards an Azu
 Both the connection string of the Azure App Configuration and the Azure Service Bus Topic will be needed in the next section, so make sure you have those.
 
 ## Usage with managed identity
-When connecting to Azure App Configuration using managed identity, you only need to provide the Azure Service Bus topic name and namespace where the the Azure App Configuration events are placed:
+When connecting to Azure App Configuration using managed identity, you only need to provide the Azure Service Bus topic name and namespace where the Azure App Configuration events are placed:
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Arcus.BackgroundJobs.AzureAppConfiguration/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.BackgroundJobs.AzureAppConfiguration/Extensions/IServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Arcus.BackgroundJobs.AzureAppConfiguration;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Pumps.ServiceBus.Configuration;
 using CloudNative.CloudEvents;
 using GuardNet;
@@ -76,29 +77,169 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddAzureAppConfiguration()
                     .AddCloudEventBackgroundJob(subscriptionNamePrefix, serviceBusTopicConnectionStringSecretKey, configureBackgroundJob)
-                    .WithServiceBusMessageHandler<RefreshAppConfigurationMessageHandler, CloudEvent>(
-                        messageBodyFilter: message => message?.Type is "Microsoft.AppConfiguration.KeyValueModified" 
-                                                      || message?.Type is "Microsoft.AppConfiguration.KeyValueDeleted",
-                        serviceProvider =>
-                        {
-                            var refresher = serviceProvider.GetService<IConfigurationRefresherProvider>();
-                            if (refresher is null)
-                            {
-                                throw new InvalidOperationException(
-                                    "Cannot handle CloudEvents that notifies changes in the Azure App Configuration because no Azure App Configuration was registered with any refresh configuration registration. " 
-                                    + $"Please use the '{nameof(AzureAppConfigurationExtensions.AddAzureAppConfiguration)}' extension when building the {nameof(IConfiguration)} " 
-                                    + $"and configure a Azure App Configuration refresh '{nameof(IConfigurationRefresher)}' registration with the '{nameof(AzureAppConfigurationOptions.ConfigureRefresh)}' extension." 
-                                    + "For more information on Azure App Configuration: https://docs.microsoft.com/en-us/azure/azure-app-configuration/");
-                            }
-
-                            var logger = 
-                                serviceProvider.GetService<ILogger<RefreshAppConfigurationMessageHandler>>() 
-                                ?? NullLogger<RefreshAppConfigurationMessageHandler>.Instance;
-
-                            return new RefreshAppConfigurationMessageHandler(refresher, logger);
-                        });
+                    .WithAppConfigurationServiceBusMessageHandler();
 
             return services;
+        }
+
+        /// <summary>
+        /// Adds a background job to automatically refresh Azure App Configuration resources based on send-out App Configuration key-value events.
+        /// </summary>
+        /// <remarks>
+        ///     Make sure that the application is configuring the Azure App Configuration when building the <see cref="IConfiguration"/> model
+        ///     For more information on Azure App Configuration: <a href="https://docs.microsoft.com/en-us/azure/azure-app-configuration/overview" />.
+        /// </remarks>
+        /// <param name="services">The services collection to add the job to.</param>
+        /// <param name="serviceBusNamespace">The Service Bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="topicName">The name of the Azure Service Bus topic to receive App Configuration events.</param>
+        /// <param name="subscriptionNamePrefix">The name of the Azure Service Bus subscription that will be created to receive App Configuration events.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="topicName"/>, <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusNamespace"/> is blank.
+        /// </exception>
+        public static IServiceCollection AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+            this IServiceCollection services,
+            string topicName,
+            string subscriptionNamePrefix,
+            string serviceBusNamespace)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a collection of services to add the re-authentication background job");
+            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus topic name to identity the Azure Service Bus entity, to receive App Configuration events");
+            Guard.NotNullOrWhitespace(subscriptionNamePrefix, nameof(subscriptionNamePrefix), "Requires a non-blank subscription name of the Azure Service Bus topic subscription, to receive Azure App Configuration events");
+            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires a non-blank fully qualified namespace for the Azure Service Bus topic, to receive App Configuration events");
+
+            return AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(services, topicName, subscriptionNamePrefix, serviceBusNamespace, clientId: null, configureBackgroundJob: null);
+        }
+
+        /// <summary>
+        /// Adds a background job to automatically refresh Azure App Configuration resources based on send-out App Configuration key-value events.
+        /// </summary>
+        /// <remarks>
+        ///     Make sure that the application is configuring the Azure App Configuration when building the <see cref="IConfiguration"/> model
+        ///     For more information on Azure App Configuration: <a href="https://docs.microsoft.com/en-us/azure/azure-app-configuration/overview" />.
+        /// </remarks>
+        /// <param name="services">The services collection to add the job to.</param>
+        /// <param name="serviceBusNamespace">The Service Bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="topicName">The name of the Azure Service Bus topic to receive App Configuration events.</param>
+        /// <param name="subscriptionNamePrefix">The name of the Azure Service Bus subscription that will be created to receive App Configuration events.</param>
+        /// <param name="configureBackgroundJob">The capability to configure additional options on how the background job should behave.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="topicName"/>, <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusNamespace"/> is blank.
+        /// </exception>
+        public static IServiceCollection AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+            this IServiceCollection services,
+            string topicName,
+            string subscriptionNamePrefix,
+            string serviceBusNamespace,
+            Action<IAzureServiceBusTopicMessagePumpOptions> configureBackgroundJob)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a collection of services to add the re-authentication background job");
+            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus topic name to identity the Azure Service Bus entity, to receive App Configuration events");
+            Guard.NotNullOrWhitespace(subscriptionNamePrefix, nameof(subscriptionNamePrefix), "Requires a non-blank subscription name of the Azure Service Bus topic subscription, to receive Azure App Configuration events");
+            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires a non-blank fully qualified namespace for the Azure Service Bus topic, to receive App Configuration events");
+
+            return AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(services, topicName, subscriptionNamePrefix, serviceBusNamespace, clientId: null, configureBackgroundJob);
+        }
+
+        /// <summary>
+        /// Adds a background job to automatically refresh Azure App Configuration resources based on send-out App Configuration key-value events.
+        /// </summary>
+        /// <remarks>
+        ///     Make sure that the application is configuring the Azure App Configuration when building the <see cref="IConfiguration"/> model
+        ///     For more information on Azure App Configuration: <a href="https://docs.microsoft.com/en-us/azure/azure-app-configuration/overview" />.
+        /// </remarks>
+        /// <param name="services">The services collection to add the job to.</param>
+        /// <param name="serviceBusNamespace">The Service Bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="topicName">The name of the Azure Service Bus topic to receive App Configuration events.</param>
+        /// <param name="subscriptionNamePrefix">The name of the Azure Service Bus subscription that will be created to receive App Configuration events.</param>
+        /// <param name="clientId">
+        ///     The client ID to authenticate for a user assigned managed identity. More information on user assigned managed identities cam be found here:
+        ///     <see href="https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm" />.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="topicName"/>, <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusNamespace"/> is blank.
+        /// </exception>
+        public static IServiceCollection AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+            this IServiceCollection services,
+            string topicName,
+            string subscriptionNamePrefix,
+            string serviceBusNamespace,
+            string clientId)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a collection of services to add the re-authentication background job");
+            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus topic name to identity the Azure Service Bus entity, to receive App Configuration events");
+            Guard.NotNullOrWhitespace(subscriptionNamePrefix, nameof(subscriptionNamePrefix), "Requires a non-blank subscription name of the Azure Service Bus topic subscription, to receive Azure App Configuration events");
+            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires a non-blank fully qualified namespace for the Azure Service Bus topic, to receive App Configuration events");
+
+            return AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(services, topicName, subscriptionNamePrefix, serviceBusNamespace, clientId, configureBackgroundJob: null);
+        }
+
+        /// <summary>
+        /// Adds a background job to automatically refresh Azure App Configuration resources based on send-out App Configuration key-value events.
+        /// </summary>
+        /// <remarks>
+        ///     Make sure that the application is configuring the Azure App Configuration when building the <see cref="IConfiguration"/> model
+        ///     For more information on Azure App Configuration: <a href="https://docs.microsoft.com/en-us/azure/azure-app-configuration/overview" />.
+        /// </remarks>
+        /// <param name="services">The services collection to add the job to.</param>
+        /// <param name="serviceBusNamespace">The Service Bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="topicName">The name of the Azure Service Bus topic to receive App Configuration events.</param>
+        /// <param name="subscriptionNamePrefix">The name of the Azure Service Bus subscription that will be created to receive App Configuration events.</param>
+        /// <param name="clientId">
+        ///     The client ID to authenticate for a user assigned managed identity. More information on user assigned managed identities cam be found here:
+        ///     <see href="https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm" />.
+        /// </param>
+        /// <param name="configureBackgroundJob">The capability to configure additional options on how the background job should behave.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="topicName"/>, <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusNamespace"/> is blank.
+        /// </exception>
+        public static IServiceCollection AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+            this IServiceCollection services,
+            string topicName,
+            string subscriptionNamePrefix,
+            string serviceBusNamespace,
+            string clientId,
+            Action<IAzureServiceBusTopicMessagePumpOptions> configureBackgroundJob)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a collection of services to add the re-authentication background job");
+            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus topic name to identity the Azure Service Bus entity, to receive App Configuration events");
+            Guard.NotNullOrWhitespace(subscriptionNamePrefix, nameof(subscriptionNamePrefix), "Requires a non-blank subscription name of the Azure Service Bus topic subscription, to receive Azure App Configuration events");
+            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires a non-blank fully qualified namespace for the Azure Service Bus topic, to receive App Configuration events");
+
+            services.AddAzureAppConfiguration()
+                    .AddCloudEventBackgroundJobUsingManagedIdentity(topicName, subscriptionNamePrefix, serviceBusNamespace, clientId, configureBackgroundJob)
+                    .WithAppConfigurationServiceBusMessageHandler();
+
+            return services;
+        }
+
+        private static void WithAppConfigurationServiceBusMessageHandler(
+            this ServiceBusMessageHandlerCollection collection)
+        {
+            collection.WithServiceBusMessageHandler<RefreshAppConfigurationMessageHandler, CloudEvent>(
+                messageBodyFilter: message => message?.Type is "Microsoft.AppConfiguration.KeyValueModified"
+                                              || message?.Type is "Microsoft.AppConfiguration.KeyValueDeleted",
+                serviceProvider =>
+                {
+                    var refresher = serviceProvider.GetService<IConfigurationRefresherProvider>();
+                    if (refresher is null)
+                    {
+                        throw new InvalidOperationException(
+                            "Cannot handle CloudEvents that notifies changes in the Azure App Configuration because no Azure App Configuration was registered with any refresh configuration registration. "
+                            + $"Please use the '{nameof(AzureAppConfigurationExtensions.AddAzureAppConfiguration)}' extension when building the {nameof(IConfiguration)} "
+                            + $"and configure a Azure App Configuration refresh '{nameof(IConfigurationRefresher)}' registration with the '{nameof(AzureAppConfigurationOptions.ConfigureRefresh)}' extension."
+                            + "For more information on Azure App Configuration: https://docs.microsoft.com/en-us/azure/azure-app-configuration/");
+                    }
+
+                    var logger =
+                        serviceProvider.GetService<ILogger<RefreshAppConfigurationMessageHandler>>()
+                        ?? NullLogger<RefreshAppConfigurationMessageHandler>.Instance;
+
+                    return new RefreshAppConfigurationMessageHandler(refresher, logger);
+                });
         }
     }
 }

--- a/src/Arcus.BackgroundJobs.Tests.Integration/AppConfiguration/AutoRefreshAppConfigurationBackgroundJobTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Integration/AppConfiguration/AutoRefreshAppConfigurationBackgroundJobTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Arcus.BackgroundJobs.Tests.Integration.AppConfiguration.Fixture;
+using Arcus.BackgroundJobs.Tests.Integration.Fixture;
 using Arcus.BackgroundJobs.Tests.Integration.Hosting;
 using Arcus.Testing.Logging;
 using Azure.Data.AppConfiguration;
+using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -33,86 +35,271 @@ namespace Arcus.BackgroundJobs.Tests.Integration.AppConfiguration
             _logger = new XunitTestLogger(outputWriter);
             _testConfiguration = TestConfig.Create();
         }
-        
+
+        private AppTestConfiguration AppConfiguration => _testConfiguration.GetAppConfiguration();
+        private ConfigurationClient AppConfigurationClient => new ConfigurationClient(AppConfiguration.ConnectionString);
+
         [Fact]
-        public async Task AutoAppConfigurationRefresh_WithModifiedKeyValue_UpdatesConfiguration()
+        public async Task AutoAppConfigurationRefreshUsingManagedIdentity_WithModifiedKeyValue_UpdatesConfiguration()
         {
             // Arrange
-            AppTestConfiguration appConfiguration = _testConfiguration.GetAppConfiguration();
-            
             const string key = "ArcusKey", value = "ArcusValue", updatedValue = "ArcusUpdatedValue";
-            var client = new ConfigurationClient(appConfiguration.ConnectionString);
-            await client.SetConfigurationSettingAsync(key, value);
+            await AppConfigurationClient.SetConfigurationSettingAsync(key, value);
 
-            var options = new WorkerOptions();
-            options.ConfigureAppConfiguration(configBuilder =>
-                   {
-                       configBuilder.AddAzureAppConfiguration(opt =>
-                       {
-                           opt.Connect(appConfiguration.ConnectionString)
-                              .ConfigureRefresh(refresh => refresh.Register(key));
-                       });
-                   })
-                   .ConfigureLogging(_logger)
-                   .ConfigureServices(services =>
-                   {
-                       services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, appConfiguration.ServiceBusTopicConnectionString))
-                               .AddAutoRefreshAppConfigurationBackgroundJob("TestSub", ServiceBusTopicConnectionStringSecretKey);
-                   });
+            ServicePrincipal servicePrincipal = _testConfiguration.GetServicePrincipal();
+            AzureEnvironment environment = _testConfiguration.GetAzureEnvironment();
 
-            await using (var worker = await Worker.StartNewAsync(options))
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureTenantId, environment.TenantId))
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientId, servicePrincipal.ClientId))
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientSecret, servicePrincipal.ClientSecret))
             {
-                var workerConfiguration = worker.ServiceProvider.GetService<IConfiguration>();
-                Assert.Equal(value, workerConfiguration.GetValue<string>(key));
+                var properties = ServiceBusConnectionStringProperties.Parse(AppConfiguration.ServiceBusTopicConnectionString);
+                var options = new WorkerOptions();
+                options.ConfigureAppConfiguration(configBuilder =>
+                       {
+                           configBuilder.AddAzureAppConfiguration(opt =>
+                           {
+                               opt.Connect(AppConfiguration.ConnectionString)
+                                  .ConfigureRefresh(refresh => refresh.Register(key));
+                           });
+                       })
+                       .ConfigureLogging(_logger)
+                       .ConfigureServices(services =>
+                       {
+                           services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, AppConfiguration.ServiceBusTopicConnectionString))
+                                   .AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(properties.EntityPath, "TestSub", properties.FullyQualifiedNamespace);
+                       });
 
-                // Act
-                await client.SetConfigurationSettingAsync(key, updatedValue);
-                
-                // Assert
-                RetryAssertion(() => Assert.Equal(updatedValue, workerConfiguration.GetValue<string>(key)),
-                    timeout: TimeSpan.FromSeconds(10),
-                    interval: TimeSpan.FromSeconds(1));
+                await using (var worker = await Worker.StartNewAsync(options))
+                {
+                    var workerConfiguration = worker.ServiceProvider.GetRequiredService<IConfiguration>();
+                    Assert.Equal(value, workerConfiguration.GetValue<string>(key));
+
+                    // Act
+                    await AppConfigurationClient.SetConfigurationSettingAsync(key, updatedValue);
+
+                    // Assert
+                    RetryAssertion(() => Assert.Equal(updatedValue, workerConfiguration.GetValue<string>(key)));
+                } 
             }
         }
 
         [Fact]
-        public async Task AutoAppConfigurationRefresh_WithDeletedKeyValue_UpdatesConfiguration()
+        public async Task AutoAppConfigurationRefreshUsingManagedIdentity_WithDeletedKeyValue_UpdatesConfiguration()
         {
             // Arrange
-            AppTestConfiguration appConfiguration = _testConfiguration.GetAppConfiguration();
-            
             const string key = "ArcusKey", value = "ArcusValue";
-            var client = new ConfigurationClient(appConfiguration.ConnectionString);
-            await client.SetConfigurationSettingAsync(key, value);
+            await AppConfigurationClient.SetConfigurationSettingAsync(key, value);
+
+            ServicePrincipal servicePrincipal = _testConfiguration.GetServicePrincipal();
+            AzureEnvironment environment = _testConfiguration.GetAzureEnvironment();
+
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureTenantId, environment.TenantId))
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientId, servicePrincipal.ClientId))
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientSecret, servicePrincipal.ClientSecret))
+            {
+                var properties = ServiceBusConnectionStringProperties.Parse(AppConfiguration.ServiceBusTopicConnectionString);
+                var options = new WorkerOptions();
+                options.ConfigureAppConfiguration(configBuilder =>
+                       {
+                           configBuilder.AddAzureAppConfiguration(opt =>
+                           {
+                               opt.Connect(AppConfiguration.ConnectionString)
+                                  .ConfigureRefresh(refresh => refresh.Register(key));
+                           });
+                       })
+                       .ConfigureLogging(_logger)
+                       .ConfigureServices(services =>
+                       {
+                           services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, AppConfiguration.ServiceBusTopicConnectionString))
+                                   .AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(properties.EntityPath, "TestSub", properties.FullyQualifiedNamespace);
+                       });
+
+                await using (var worker = await Worker.StartNewAsync(options))
+                {
+                    var workerConfiguration = worker.ServiceProvider.GetRequiredService<IConfiguration>();
+                    Assert.Equal(value, workerConfiguration.GetValue<string>(key));
+
+                    // Act
+                    await AppConfigurationClient.DeleteConfigurationSettingAsync(key);
+                
+                    // Assert
+                    RetryAssertion(() => Assert.Null(workerConfiguration.GetValue<string>(key)));
+                } 
+            }
+        }
+
+        [Fact]
+        public async Task AutoAppConfigurationRefresh_WithModifiedKeyValue_UpdatesConfiguration()
+        {
+            // Arrange
+            const string key = "ArcusKey", value = "ArcusValue", updatedValue = "ArcusUpdatedValue";
+            await AppConfigurationClient.SetConfigurationSettingAsync(key, value);
 
             var options = new WorkerOptions();
             options.ConfigureAppConfiguration(configBuilder =>
                    {
                        configBuilder.AddAzureAppConfiguration(opt =>
                        {
-                           opt.Connect(appConfiguration.ConnectionString)
+                           opt.Connect(AppConfiguration.ConnectionString)
                               .ConfigureRefresh(refresh => refresh.Register(key));
                        });
                    })
                    .ConfigureLogging(_logger)
                    .ConfigureServices(services =>
                    {
-                       services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, appConfiguration.ServiceBusTopicConnectionString))
+                       services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, AppConfiguration.ServiceBusTopicConnectionString))
                                .AddAutoRefreshAppConfigurationBackgroundJob("TestSub", ServiceBusTopicConnectionStringSecretKey);
                    });
 
             await using (var worker = await Worker.StartNewAsync(options))
             {
-                var workerConfiguration = worker.ServiceProvider.GetService<IConfiguration>();
+                var workerConfiguration = worker.ServiceProvider.GetRequiredService<IConfiguration>();
                 Assert.Equal(value, workerConfiguration.GetValue<string>(key));
 
                 // Act
-                await client.DeleteConfigurationSettingAsync(key);
+                await AppConfigurationClient.SetConfigurationSettingAsync(key, updatedValue);
                 
                 // Assert
-                RetryAssertion(() => Assert.Null(workerConfiguration.GetValue<string>(key)),
-                    timeout: TimeSpan.FromSeconds(10),
-                    interval: TimeSpan.FromSeconds(1));
+                RetryAssertion(() => Assert.Equal(updatedValue, workerConfiguration.GetValue<string>(key)));
+            }
+        }
+
+         [Fact]
+        public async Task AutoAppConfigurationRefresh_WithDeletedKeyValue_UpdatesConfiguration()
+        {
+            // Arrange
+            const string key = "ArcusKey", value = "ArcusValue";
+            await AppConfigurationClient.SetConfigurationSettingAsync(key, value);
+
+            var options = new WorkerOptions();
+            options.ConfigureAppConfiguration(configBuilder =>
+                   {
+                       configBuilder.AddAzureAppConfiguration(opt =>
+                       {
+                           opt.Connect(AppConfiguration.ConnectionString)
+                              .ConfigureRefresh(refresh => refresh.Register(key));
+                       });
+                   })
+                   .ConfigureLogging(_logger)
+                   .ConfigureServices(services =>
+                   {
+                       services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, AppConfiguration.ServiceBusTopicConnectionString))
+                               .AddAutoRefreshAppConfigurationBackgroundJob("TestSub", ServiceBusTopicConnectionStringSecretKey);
+                   });
+
+            await using (var worker = await Worker.StartNewAsync(options))
+            {
+                var workerConfiguration = worker.ServiceProvider.GetRequiredService<IConfiguration>();
+                Assert.Equal(value, workerConfiguration.GetValue<string>(key));
+
+                // Act
+                await AppConfigurationClient.DeleteConfigurationSettingAsync(key);
+                
+                // Assert
+               RetryAssertion(() => Assert.Null(workerConfiguration.GetValue<string>(key)));
+            }
+        }
+
+        [Fact]
+        public async Task AutoAppConfigurationRefreshUsingManagedIdentity_WithModifiedFeatureToggle_UpdatesConfiguration()
+        {
+            // Arrange
+            const string key = "ArcusFeature";
+            await AppConfigurationClient.SetConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: true));
+
+            ServicePrincipal servicePrincipal = _testConfiguration.GetServicePrincipal();
+            AzureEnvironment environment = _testConfiguration.GetAzureEnvironment();
+
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureTenantId, environment.TenantId))
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientId, servicePrincipal.ClientId))
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientSecret, servicePrincipal.ClientSecret))
+            {
+                var properties = ServiceBusConnectionStringProperties.Parse(AppConfiguration.ServiceBusTopicConnectionString);
+                var options = new WorkerOptions();
+                options.ConfigureAppConfiguration(configBuilder =>
+                       {
+                           configBuilder.AddAzureAppConfiguration(opt =>
+                           {
+                               opt.Connect(AppConfiguration.ConnectionString)
+                                  .ConfigureRefresh(refreshOptions => refreshOptions.Register(key))
+                                  .UseFeatureFlags();
+                           });
+                       })
+                       .ConfigureLogging(_logger)
+                       .ConfigureServices(services =>
+                       {
+                           services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, AppConfiguration.ServiceBusTopicConnectionString))
+                                   .AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(properties.EntityPath, "TestSub", properties.FullyQualifiedNamespace)
+                                   .AddFeatureManagement();
+                       });
+
+                await using (var worker = await Worker.StartNewAsync(options))
+                {
+                    var featureManager = worker.ServiceProvider.GetRequiredService<IFeatureManager>();
+                    Assert.True(await featureManager.IsEnabledAsync(key));
+
+                    // Act
+                    await AppConfigurationClient.SetConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: false));
+
+                    // Assert
+                    await RetryAssertionAsync(async () =>
+                    {
+                        bool isEnabled = await featureManager.IsEnabledAsync(key);
+                        Assert.False(isEnabled);
+                    });
+                } 
+            }
+        }
+
+         [Fact]
+        public async Task AutoAppConfigurationRefreshUsingManagedIdentity_WithDeletedFeatureToggle_UpdatesConfiguration()
+        {
+             // Arrange
+            const string key = "ArcusFeature";
+            await AppConfigurationClient.SetConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: true));
+
+            ServicePrincipal servicePrincipal = _testConfiguration.GetServicePrincipal();
+            AzureEnvironment environment = _testConfiguration.GetAzureEnvironment();
+
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureTenantId, environment.TenantId))
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientId, servicePrincipal.ClientId))
+            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientSecret, servicePrincipal.ClientSecret))
+            {
+                var properties = ServiceBusConnectionStringProperties.Parse(AppConfiguration.ServiceBusTopicConnectionString);
+                var options = new WorkerOptions();
+                options.ConfigureAppConfiguration(configBuilder =>
+                       {
+                           configBuilder.AddAzureAppConfiguration(opt =>
+                           {
+                               opt.Connect(AppConfiguration.ConnectionString)
+                                  .ConfigureRefresh(refreshOptions => refreshOptions.Register(key))
+                                  .UseFeatureFlags();
+                           });
+                       })
+                       .ConfigureLogging(_logger)
+                       .ConfigureServices(services =>
+                       {
+                           services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, AppConfiguration.ServiceBusTopicConnectionString))
+                                   .AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(properties.EntityPath, "TestSub", properties.FullyQualifiedNamespace)
+                                   .AddFeatureManagement();
+                       });
+
+                await using (var worker = await Worker.StartNewAsync(options))
+                {
+                    var featureManager = worker.ServiceProvider.GetRequiredService<IFeatureManager>();
+                    Assert.True(await featureManager.IsEnabledAsync(key));
+
+                    // Act
+                    await AppConfigurationClient.DeleteConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: false));
+
+                    // Assert
+                    await RetryAssertionAsync(async () =>
+                    {
+                        bool isEnabled = await featureManager.IsEnabledAsync(key);
+                        Assert.False(isEnabled);
+                    });
+                } 
             }
         }
 
@@ -120,18 +307,15 @@ namespace Arcus.BackgroundJobs.Tests.Integration.AppConfiguration
         public async Task AutoAppConfigurationRefresh_WithModifiedFeatureToggle_UpdatesConfiguration()
         {
             // Arrange
-            AppTestConfiguration appConfiguration = _testConfiguration.GetAppConfiguration();
-
             const string key = "ArcusFeature";
-            var client = new ConfigurationClient(appConfiguration.ConnectionString);
-            await client.SetConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: true));
+            await AppConfigurationClient.SetConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: true));
 
             var options = new WorkerOptions();
             options.ConfigureAppConfiguration(configBuilder =>
                    {
                        configBuilder.AddAzureAppConfiguration(opt =>
                        {
-                           opt.Connect(appConfiguration.ConnectionString)
+                           opt.Connect(AppConfiguration.ConnectionString)
                               .ConfigureRefresh(refreshOptions => refreshOptions.Register(key))
                               .UseFeatureFlags();
                        });
@@ -139,27 +323,25 @@ namespace Arcus.BackgroundJobs.Tests.Integration.AppConfiguration
                    .ConfigureLogging(_logger)
                    .ConfigureServices(services =>
                    {
-                       services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, appConfiguration.ServiceBusTopicConnectionString))
+                       services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, AppConfiguration.ServiceBusTopicConnectionString))
                                .AddAutoRefreshAppConfigurationBackgroundJob("TestSub", ServiceBusTopicConnectionStringSecretKey)
                                .AddFeatureManagement();
                    });
 
             await using (var worker = await Worker.StartNewAsync(options))
             {
-                var featureManager = worker.ServiceProvider.GetService<IFeatureManager>();
+                var featureManager = worker.ServiceProvider.GetRequiredService<IFeatureManager>();
                 Assert.True(await featureManager.IsEnabledAsync(key));
 
                 // Act
-                await client.SetConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: false));
+                await AppConfigurationClient.SetConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: false));
                 
                 // Assert
                 await RetryAssertionAsync(async () =>
-                    {
-                        bool isEnabled = await featureManager.IsEnabledAsync(key);
-                        Assert.False(isEnabled);
-                    },
-                    timeout: TimeSpan.FromSeconds(10),
-                    interval: TimeSpan.FromSeconds(1));
+                {
+                    bool isEnabled = await featureManager.IsEnabledAsync(key);
+                    Assert.False(isEnabled);
+                });
             }
         }
 
@@ -167,18 +349,15 @@ namespace Arcus.BackgroundJobs.Tests.Integration.AppConfiguration
         public async Task AutoAppConfigurationRefresh_WithDeletedFeatureToggle_UpdatesConfiguration()
         {
              // Arrange
-            AppTestConfiguration appConfiguration = _testConfiguration.GetAppConfiguration();
-
             const string key = "ArcusFeature";
-            var client = new ConfigurationClient(appConfiguration.ConnectionString);
-            await client.SetConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: true));
+            await AppConfigurationClient.SetConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: true));
 
             var options = new WorkerOptions();
             options.ConfigureAppConfiguration(configBuilder =>
                    {
                        configBuilder.AddAzureAppConfiguration(opt =>
                        {
-                           opt.Connect(appConfiguration.ConnectionString)
+                           opt.Connect(AppConfiguration.ConnectionString)
                               .ConfigureRefresh(refreshOptions => refreshOptions.Register(key))
                               .UseFeatureFlags();
                        });
@@ -186,43 +365,41 @@ namespace Arcus.BackgroundJobs.Tests.Integration.AppConfiguration
                    .ConfigureLogging(_logger)
                    .ConfigureServices(services =>
                    {
-                       services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, appConfiguration.ServiceBusTopicConnectionString))
+                       services.AddSecretStore(stores => stores.AddInMemory(ServiceBusTopicConnectionStringSecretKey, AppConfiguration.ServiceBusTopicConnectionString))
                                .AddAutoRefreshAppConfigurationBackgroundJob("TestSub", ServiceBusTopicConnectionStringSecretKey)
                                .AddFeatureManagement();
                    });
 
             await using (var worker = await Worker.StartNewAsync(options))
             {
-                var featureManager = worker.ServiceProvider.GetService<IFeatureManager>();
+                var featureManager = worker.ServiceProvider.GetRequiredService<IFeatureManager>();
                 Assert.True(await featureManager.IsEnabledAsync(key));
 
                 // Act
-                await client.DeleteConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: false));
+                await AppConfigurationClient.DeleteConfigurationSettingAsync(new FeatureFlagConfigurationSetting(key, isEnabled: false));
                 
                 // Assert
                 await RetryAssertionAsync(async () =>
-                    {
-                        bool isEnabled = await featureManager.IsEnabledAsync(key);
-                        Assert.False(isEnabled);
-                    },
-                    timeout: TimeSpan.FromSeconds(10),
-                    interval: TimeSpan.FromSeconds(1));
+                {
+                    bool isEnabled = await featureManager.IsEnabledAsync(key);
+                    Assert.False(isEnabled);
+                });
             }
         }
 
-        private static async Task RetryAssertionAsync(Func<Task> assertion, TimeSpan timeout, TimeSpan interval)
+        private static async Task RetryAssertionAsync(Func<Task> assertion)
         {
-            await Policy.TimeoutAsync(timeout)
+            await Policy.TimeoutAsync(TimeSpan.FromSeconds(10))
                         .WrapAsync(Policy.Handle<AssertActualExpectedException>()
-                                         .WaitAndRetryForeverAsync(index => interval))
+                                         .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(1)))
                         .ExecuteAsync(assertion);
         }
         
-        private static void RetryAssertion(Action assertion, TimeSpan timeout, TimeSpan interval)
+        private static void RetryAssertion(Action assertion)
         {
-            Policy.Timeout(timeout)
+            Policy.Timeout(TimeSpan.FromSeconds(10))
                   .Wrap(Policy.Handle<AssertActualExpectedException>()
-                              .WaitAndRetryForever(index => interval))
+                              .WaitAndRetryForever(index => TimeSpan.FromSeconds(1)))
                   .Execute(assertion);
         }
     }

--- a/src/Arcus.BackgroundJobs.Tests.Unit/AppConfiguration/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.BackgroundJobs.Tests.Unit/AppConfiguration/IServiceCollectionExtensionsTests.cs
@@ -10,6 +10,198 @@ namespace Arcus.BackgroundJobs.Tests.Unit.AppConfiguration
     {
         [Theory]
         [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithoutOptions_WithoutTopicName_Fails(string topicName)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    topicName,
+                    "<subscription-name-prefix>",
+                    "<service-bus-namespace>"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithoutOptions_WithoutSubscriptionPrefix_Fails(string subscriptionNamePrefix)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    "<topic-name>",
+                    subscriptionNamePrefix,
+                    "<service-bus-namespace>"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithoutOptions_WithoutServiceBusNamespace_Fails(string serviceBusNamespace)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    "<topic-name>",
+                    "<subscription-name-prefix>",
+                    serviceBusNamespace));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithOptions_WithoutTopicName_Fails(string topicName)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    topicName,
+                    "<subscription-name-prefix>",
+                    "<service-bus-namespace>",
+                    options => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithOptions_WithoutSubscriptionPrefix_Fails(string subscriptionNamePrefix)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    "<topic-name>",
+                    subscriptionNamePrefix,
+                    "<service-bus-namespace>",
+                    options => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithOptions_WithoutServiceBusNamespace_Fails(string serviceBusNamespace)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    "<topic-name>",
+                    "<subscription-name-prefix>",
+                    serviceBusNamespace,
+                    options => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithClientIdWithoutOptions_WithoutTopicName_Fails(string topicName)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    topicName,
+                    "<subscription-name-prefix>",
+                    "<service-bus-namespace>",
+                    "<client-id>"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithClientIdWithOptionsOptions_WithoutSubscriptionPrefix_Fails(string subscriptionNamePrefix)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    "<topic-name>",
+                    subscriptionNamePrefix,
+                    "<service-bus-namespace>",
+                    "<client-id>"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithClientIdWithoutOptions_WithoutServiceBusNamespace_Fails(string serviceBusNamespace)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    "<topic-name>",
+                    "<subscription-name-prefix>",
+                    serviceBusNamespace,
+                    "<client-id>"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithClientIdWithOptions_WithoutTopicName_Fails(string topicName)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    topicName,
+                    "<subscription-name-prefix>",
+                    "<service-bus-namespace>",
+                    "<client-id>",
+                    options => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithClientIdWithOptions_WithoutSubscriptionPrefix_Fails(string subscriptionNamePrefix)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    "<topic-name>",
+                    subscriptionNamePrefix,
+                    "<service-bus-namespace>",
+                    "<client-id>",
+                    options => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddJobUsingManagedIdentityWithClientIdWithOptions_WithoutServiceBusNamespace_Fails(string serviceBusNamespace)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAutoRefreshAppConfigurationBackgroundJobUsingManagedIdentity(
+                    "<topic-name>",
+                    "<subscription-name-prefix>",
+                    serviceBusNamespace,
+                    "<client-id>",
+                    options => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
         public void AddJobWithoutOptions_WithoutSubscriptionPrefix_Fails(string subscriptionNamePrefix)
         {
             // Arrange
@@ -21,7 +213,7 @@ namespace Arcus.BackgroundJobs.Tests.Unit.AppConfiguration
                     subscriptionNamePrefix,
                     "<service-bus-topic-connection-string-secret-key>"));
         }
-        
+
         [Theory]
         [ClassData(typeof(Blanks))]
         public void AddJobWithoutOptions_WithoutServiceBusTopicConnectionStringSecretKey_Fails(string serviceBusTopicConnectionStringSecretKey)


### PR DESCRIPTION
Add managed identity support for the Azure App Configuration background job that auto-refreshes the application configuration.

Closes #156